### PR TITLE
Detect non-base64 encoded files and binary req/res data

### DIFF
--- a/lib/dradis/plugins/burp/gem_version.rb
+++ b/lib/dradis/plugins/burp/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 3
         MINOR = 0
-        TINY = 1
+        TINY = 2
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/dradis/plugins/burp/importer.rb
+++ b/lib/dradis/plugins/burp/importer.rb
@@ -7,6 +7,15 @@ module Dradis::Plugins::Burp
     def import(params = {})
       file_content = File.read( params[:file] )
 
+      if file_content =~ /base64="false"/
+        error =  "Burp input contains HTTP request / response data that hasn't been Base64-encoded.\n"
+        error << "Please re-export your scanner results making sure the Base-64 encode option is selected."
+
+        logger.fatal{ error }
+        content_service.create_note text: error
+        return false
+      end
+
       logger.info{ 'Parsing Burp Scanner output file...' }
       doc = Nokogiri::XML( file_content )
       logger.info{'Done.'}


### PR DESCRIPTION
This PR adds two pieces of functionality:

* Before any parsing is attempted we try to locate `<request>` / `<response>` tags where `base64="false"`, these would include unencoded binary data that we can't easily handle. We fail early and warn the user.

* For files with Base-64 encoded requests and responses some times, after decoding the response will contain binary data (like a .ttf font body). Before we'd try to save this in the :text column of the database causing a number of problems in the proces. This change detects binary data presence (by checking for a null byte) and if found, limits the response to the HTTP headers.