### PR TITLE
Encode the content using utf-8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ Gemfile.lock
 # Gem artifacts
 /pkg/
 /spec/internal/
+
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.8.1 (XX, 2017) ##
+
+*   Encode content with UTF-8 to avoid incompatible db errors.
+
 ## Dradis Framework 3.8 (September, 2017) ##
 
 *   No changes.

--- a/lib/burp/issue.rb
+++ b/lib/burp/issue.rb
@@ -144,6 +144,9 @@ module Burp
       # TODO: maybe add a reference to this node's XPATH so the user can go
       # back to the burp scanner file and look up the original request/response
       result.truncate(50000, omission: '... (truncated)')
+
+      # Encode the string to utf-8 to catch invalid bytes.
+      result.encode('utf-8', invalid: :replace, undef: :replace)
     end
   end
 end

--- a/lib/burp/issue.rb
+++ b/lib/burp/issue.rb
@@ -1,4 +1,7 @@
 module Burp
+  # We use this string to replace invalid UTF-8 bytes with.
+  INVALID_UTF_REPLACE = '<?>'
+
   # This class represents each of the /issues/issue elements in the Burp
   # Scanner XML document.
   #
@@ -8,7 +11,6 @@ module Burp
   # Instead of providing separate methods for each supported property we rely
   # on Ruby's #method_missing to do most of the work.
   class Issue
-    INVALID_UTF_REPLACE = "<?>"
 
     # Accepts an XML node from Nokogiri::XML.
     def initialize(xml_node)
@@ -147,8 +149,8 @@ module Burp
       # back to the burp scanner file and look up the original request/response
       result.truncate(50000, omission: '... (truncated)')
 
-      # Encode the string to utf-8 to catch invalid bytes.
-      result.encode('utf-8', invalid: :replace, undef: :replace, replace: INVALID_UTF_REPLACE)
+      # Encode the string to UTF-8 to catch invalid bytes.
+      result.encode('utf-8', invalid: :replace, undef: :replace, replace: ::Burp::INVALID_UTF_REPLACE)
     end
   end
 end

--- a/lib/burp/issue.rb
+++ b/lib/burp/issue.rb
@@ -8,6 +8,8 @@ module Burp
   # Instead of providing separate methods for each supported property we rely
   # on Ruby's #method_missing to do most of the work.
   class Issue
+    INVALID_UTF_REPLACE = "<?>"
+
     # Accepts an XML node from Nokogiri::XML.
     def initialize(xml_node)
       @xml = xml_node
@@ -146,7 +148,7 @@ module Burp
       result.truncate(50000, omission: '... (truncated)')
 
       # Encode the string to utf-8 to catch invalid bytes.
-      result.encode('utf-8', invalid: :replace, undef: :replace)
+      result.encode('utf-8', invalid: :replace, undef: :replace, replace: INVALID_UTF_REPLACE)
     end
   end
 end

--- a/lib/dradis/plugins/burp/gem_version.rb
+++ b/lib/dradis/plugins/burp/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 3
         MINOR = 8
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/dradis/plugins/burp/importer.rb
+++ b/lib/dradis/plugins/burp/importer.rb
@@ -55,6 +55,13 @@ module Dradis::Plugins::Burp
           template: 'issue',
           data: xml_issue)
 
+        if issue_text.include?(::Burp::Issue::INVALID_UTF_REPLACE)
+          logger.info %{
+            "\tdetected invalid UTF-8 bytes in your issue. " \
+            "Replacing them with '#{::Burp::Issue::INVALID_UTF_REPLACE}'."
+          }
+        end
+
         issue = content_service.create_issue(
           text: issue_text,
           id: issue_type)
@@ -65,6 +72,13 @@ module Dradis::Plugins::Burp
           template: 'evidence',
           data: xml_issue
         )
+
+        if evidence_text.include?(::Burp::Issue::INVALID_UTF_REPLACE)
+          logger.info {
+            "\tdetected invalid UTF-8 bytes in your evidence. " \
+            "Replacing them with '#{::Burp::Issue::INVALID_UTF_REPLACE}'."
+          }
+        end
 
         content_service.create_evidence(
           issue: issue,

--- a/lib/dradis/plugins/burp/importer.rb
+++ b/lib/dradis/plugins/burp/importer.rb
@@ -55,10 +55,10 @@ module Dradis::Plugins::Burp
           template: 'issue',
           data: xml_issue)
 
-        if issue_text.include?(::Burp::Issue::INVALID_UTF_REPLACE)
+        if issue_text.include?(::Burp::INVALID_UTF_REPLACE)
           logger.info %{
             "\tdetected invalid UTF-8 bytes in your issue. " \
-            "Replacing them with '#{::Burp::Issue::INVALID_UTF_REPLACE}'."
+            "Replacing them with '#{::Burp::INVALID_UTF_REPLACE}'."
           }
         end
 
@@ -73,10 +73,10 @@ module Dradis::Plugins::Burp
           data: xml_issue
         )
 
-        if evidence_text.include?(::Burp::Issue::INVALID_UTF_REPLACE)
+        if evidence_text.include?(::Burp::INVALID_UTF_REPLACE)
           logger.info {
             "\tdetected invalid UTF-8 bytes in your evidence. " \
-            "Replacing them with '#{::Burp::Issue::INVALID_UTF_REPLACE}'."
+            "Replacing them with '#{::Burp::INVALID_UTF_REPLACE}'."
           }
         end
 

--- a/lib/dradis/plugins/burp/importer.rb
+++ b/lib/dradis/plugins/burp/importer.rb
@@ -63,12 +63,14 @@ module Dradis::Plugins::Burp
 
         evidence_text = template_service.process_template(
           template: 'evidence',
-          data: xml_issue)
+          data: xml_issue
+        )
 
         content_service.create_evidence(
           issue: issue,
           node: affected_host,
-          content: evidence_text)
+          content: evidence_text
+        )
 
       end
       logger.info{ 'Burp Scanner results successfully imported' }

--- a/spec/burp_upload_spec.rb
+++ b/spec/burp_upload_spec.rb
@@ -4,7 +4,13 @@ require 'ostruct'
 describe 'Burp upload plugin' do
 
   describe Burp::Issue do
-    pending "create some unit tests for the Burp::Issue wrapper class"
+    it "handles invalid utf-8 bytes" do
+      doc = Nokogiri::XML(File.read('spec/fixtures/files/invalid-utf-issue.xml'))
+      xml_issue = doc.xpath('issues/issue').first
+      issue = Burp::Issue.new(xml_issue)
+
+      expect{ issue.request.encode('utf-8') }.to_not raise_error
+    end
   end
 
   describe "Importer" do
@@ -17,12 +23,13 @@ describe 'Burp upload plugin' do
       # Init services
       plugin = Dradis::Plugins::Burp
 
-      @content_service = Dradis::Plugins::ContentService.new(plugin: plugin)
-      template_service = Dradis::Plugins::TemplateService.new(plugin: plugin)
+      @content_service = Dradis::Plugins::ContentService::Base.new(
+        logger: Logger.new(STDOUT),
+        plugin: plugin
+      )
 
       @importer = plugin::Importer.new(
         content_service: @content_service,
-        template_service: template_service
       )
 
       # Stub dradis-plugins methods

--- a/spec/fixtures/files/invalid-utf-issue.xml
+++ b/spec/fixtures/files/invalid-utf-issue.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<issues>
+  <issue>
+    <serialNumber>1833460934674078320</serialNumber>
+    <type>8781630</type>
+    <name>Issue 1</name>
+    <host ip="10.0.0.1">http://www.test.com</host>
+    <path><![CDATA[/Common/login.aspx\xc3\x28\255]]></path>
+    <location><![CDATA[/Common/login.aspx\xC3(]]></location>
+    <severity>Information</severity>
+    <confidence>Firm</confidence>
+    <issueBackground><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit. Veniam fugiat possimus quaerat esse aspernatur cumque, fugit incidunt tempora nam ex atque, magni alias ullam illo voluptate sed consequatur reprehenderit qui.]]></issueBackground>
+    <remediationBackground><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit. Explicabo itaque unde numquam, nihil eveniet deleniti dignissimos architecto quo neque ea impedit nam autem iusto iste, esse, aut minus animi repellat.]]></remediationBackground>
+    <issueDetail><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit. Corporis quisquam aut necessitatibus ex possimus suscipit ipsam ipsa repellendus quo nostrum! Dolores quibusdam modi impedit nihil necessitatibus dicta vitae dolorem sit!]]></issueDetail>
+    <requestresponse>
+      <request base64="true"><![CDATA[liBUcnVlIHdvcmtlcpI=]]></request>
+      <response base64="true"><![CDATA[TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2ljaW5nIGVsaXQuIFNhcGllbnRlIGZ1Z2lhdCBlYXJ1bSwgYW5pbWkgdmVybyBxdWlidXNkYW0gc2VkLCBkb2xvcnVtIGRpc3RpbmN0aW8gYWxpcXVhbSwgcmVpY2llbmRpcyBjb3Jwb3JpcyBuaWhpbCBleGNlcHR1cmkgY29uc2VjdGV0dXIgZGVsZW5pdGkgbW9sZXN0aWFzIGhhcnVtIGxhYm9yaW9zYW0gc3VudCBub3N0cnVtIG9kaW8u]]></response>
+      <responseRedirected>false</responseRedirected>
+    </requestresponse>
+  </issue>
+</issues>


### PR DESCRIPTION
When uploading a Burp scan with invalid utf-8 bytes, the Mysql throws an error: `Mysql2::Error: Incorrect string value: ‘\x…’ for column ‘content’ at row 1:...`

We need to make sure that the content string that we pass on our issues/evidences are valid strings so we encode it to utf-8 and replace the invalid and undefined bytes.

## How to test:
1. Upload a Burp file with invalid utf-8 characters
2. Assert that the upload was successful.