### PR TITLE
Add new available fields + Node Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Dradis Framework 3.9 (December, 2017) ##
+
+*   Adds `references` and `vulnerability_classifications` as available fields
+
+*   Adds `hostname` as a Node property
+
+*   Fixes formatting errors including `<p>`, `<a href="">`, and `<table>` tags
+
 ## Dradis Framework 3.8 (September, 2017) ##
 
 *   No changes.

--- a/lib/burp/issue.rb
+++ b/lib/burp/issue.rb
@@ -22,7 +22,7 @@ module Burp
         # simple tags
         :serial_number, :type, :name, :host, :path, :location, :severity,
         :confidence, :background, :remediation_background, :detail,
-        :remediation_detail, :references,
+        :remediation_detail, :references, :vulnerability_classifications,
 
         # nested tags
         :request, :response
@@ -60,6 +60,7 @@ module Burp
         :detail => 'issueDetail',
         :remediation_background => 'remediationBackground',
         :remediation_detail => 'remediationDetail',
+        :vulnerability_classifications => 'vulnerabilityClassifications',
         :serial_number => 'serialNumber'
       }
 
@@ -117,7 +118,7 @@ module Burp
 
     # Some of the values have embedded HTML content that we need to strip
     def tags_with_html_content
-      [:background, :detail, :remediation_background, :remediation_detail, :references]
+      [:background, :detail, :remediation_background, :remediation_detail, :references, :vulnerability_classifications]
     end
 
     def requestresponse_child(field)

--- a/lib/burp/issue.rb
+++ b/lib/burp/issue.rb
@@ -22,7 +22,7 @@ module Burp
         # simple tags
         :serial_number, :type, :name, :host, :path, :location, :severity,
         :confidence, :background, :remediation_background, :detail,
-        :remediation_detail,
+        :remediation_detail, :references,
 
         # nested tags
         :request, :response
@@ -102,19 +102,22 @@ module Burp
       result.gsub!(/<h2>(.*?)<\/h2>/, '*\1*')
       result.gsub!(/<i>(.*?)<\/i>/, '\1')
       result.gsub!(/<p>(.*?)<\/p>/, '\1')
+      result.gsub!(/<p>/, '')
+      result.gsub!(/<\/p>/, '')
       result.gsub!(/<pre.*?>(.*?)<\/pre>/m){|m| "\n\nbc.. #{ $1 }\n\np.  \n" }
 
       result.gsub!(/<ul>/, "\n")
       result.gsub!(/<\/ul>/, "\n")
       result.gsub!(/<li>/, "\n* ")
       result.gsub!(/<\/li>/, "\n")
-
+      result.gsub!(/<a href=\"(.*?)\">(.*?)<\/a>/i) { "\"#{$2.strip}\":#{$1.strip}" }
+      
       result
     end
 
     # Some of the values have embedded HTML content that we need to strip
     def tags_with_html_content
-      [:background, :detail, :remediation_background, :remediation_detail]
+      [:background, :detail, :remediation_background, :remediation_detail, :references]
     end
 
     def requestresponse_child(field)

--- a/lib/burp/issue.rb
+++ b/lib/burp/issue.rb
@@ -95,24 +95,24 @@ module Burp
       result.gsub!(/&amp;/, '&')
       result.gsub!(/&lt;/, '<')
       result.gsub!(/&gt;/, '>')
+      result.gsub!(/&nbsp;/, ' ')
 
       result.gsub!(/<b>(.*?)<\/b>/, '*\1*')
-      result.gsub!(/<br\/>/, "\n")
-      result.gsub!(/<br>/, "\n")
+      result.gsub!(/<br>|<\/br>/){"\n"}
       result.gsub!(/<font.*?>(.*?)<\/font>/m, '\1')
-      result.gsub!(/<h2>(.*?)<\/h2>/, '*\1*')
+      result.gsub!(/<h\d?>(.*?)<\/h\d?>/, '*\1*')
       result.gsub!(/<i>(.*?)<\/i>/, '\1')
-      result.gsub!(/<p>(.*?)<\/p>/, '\1')
-      result.gsub!(/<p>/, '')
-      result.gsub!(/<\/p>/, '')
+      result.gsub!(/<p>|<\/p>/){"\n"}
       result.gsub!(/<pre.*?>(.*?)<\/pre>/m){|m| "\n\nbc.. #{ $1 }\n\np.  \n" }
 
-      result.gsub!(/<ul>/, "\n")
-      result.gsub!(/<\/ul>/, "\n")
-      result.gsub!(/<li>/, "\n* ")
-      result.gsub!(/<\/li>/, "\n")
+      result.gsub!(/<ul>(.*?)<\/ul>/m){|m| "#{ $1 }\n"}
+      result.gsub!(/<li>(.*?)<\/li>/m){|m| "\n* #{ $1 }"}
       result.gsub!(/<a href=\"(.*?)\">(.*?)<\/a>/i) { "\"#{$2.strip}\":#{$1.strip}" }
-      
+
+      result.gsub!(/<table>(.*?)<\/table>/m){|m| "\n\n#{ $1 }\n\n" }
+      result.gsub!(/<tr>(.*?)<\/tr>/m){|m| "|#{ $1 }\n" }
+      result.gsub!(/<td>(.*?)<\/td>/, '\1|')
+
       result
     end
 

--- a/lib/dradis/plugins/burp/gem_version.rb
+++ b/lib/dradis/plugins/burp/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 3
         MINOR = 8
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/dradis/plugins/burp/gem_version.rb
+++ b/lib/dradis/plugins/burp/gem_version.rb
@@ -8,8 +8,8 @@ module Dradis
 
       module VERSION
         MAJOR = 3
-        MINOR = 8
-        TINY = 1
+        MINOR = 9
+        TINY = 0
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/dradis/plugins/burp/importer.rb
+++ b/lib/dradis/plugins/burp/importer.rb
@@ -47,8 +47,8 @@ module Dradis::Plugins::Burp
         if !hosts.include?(affected_host.label)
           hosts << affected_host.label
           url = xml_issue.at('host').text
-          host_description = "\#[HostInfo]\#\n#{ url }\n\n"
-          content_service.create_note(text: host_description, node: affected_host)
+          affected_host.set_property(:hostname, url)
+          affected_host.save
         end
 
         issue_text = template_service.process_template(

--- a/spec/burp_upload_spec.rb
+++ b/spec/burp_upload_spec.rb
@@ -1,12 +1,23 @@
 require 'spec_helper'
 require 'ostruct'
 
-module Dradis::Plugins
-  describe 'Burp upload plugin' do
+describe 'Burp upload plugin' do
+
+  describe Burp::Issue do
+    it "handles invalid utf-8 bytes" do
+      doc = Nokogiri::XML(File.read('spec/fixtures/files/invalid-utf-issue.xml'))
+      xml_issue = doc.xpath('issues/issue').first
+      issue = Burp::Issue.new(xml_issue)
+
+      expect{ issue.request.encode('utf-8') }.to_not raise_error
+    end
+  end
+
+  describe "Importer" do
     before(:each) do
       # Stub template service
       templates_dir = File.expand_path('../../templates', __FILE__)
-      expect_any_instance_of(TemplateService)
+      expect_any_instance_of(Dradis::Plugins::TemplateService)
       .to receive(:default_templates_dir).and_return(templates_dir)
 
       # Init services

--- a/templates/issue.fields
+++ b/templates/issue.fields
@@ -4,3 +4,4 @@ issue.remediation_background
 issue.detail
 issue.remediation_detail
 issue.references
+issue.vulnerability_classifications

--- a/templates/issue.fields
+++ b/templates/issue.fields
@@ -3,3 +3,4 @@ issue.background
 issue.remediation_background
 issue.detail
 issue.remediation_detail
+issue.references

--- a/templates/issue.sample
+++ b/templates/issue.sample
@@ -1,12 +1,23 @@
 <issue>
-  <serialNumber>5236964506139299840</serialNumber>
-  <type>6291712</type>
-  <name>Directory listing</name>
-  <host ip="10.0.0.1">http://wiki.local</host>
-  <path><![CDATA[/crmmanager/]]></path>
-  <location><![CDATA[/crmmanager/]]></location>
-  <severity>Information</severity>
-  <confidence>Firm</confidence>
-  <issueBackground><![CDATA[Directory listings do not necessarily constitute a security vulnerability. Any sensitive resources within your web root should be properly access-controlled in any case, and should not be accessible by an unauthorized party who happens to know the URL. Nevertheless, directory listings can aid an attacker by enabling them to quickly identify the resources at a given path, and proceed directly to analyzing and attacking them.]]></issueBackground>
-  <remediationBackground><![CDATA[There is not usually any good reason to provide directory listings, and disabling them may place additional hurdles in the path of an attacker. This can normally be achieved in two ways:<ul><li>Configure your web server to prevent directory listings for all paths beneath the web root; </li><li>Place into each directory a default file (such as index.htm) which the web server will display instead of returning a directory listing.</li></ul>]]></remediationBackground>
+  <serialNumber>5863488220648493056</serialNumber>
+  <type>16777984</type>
+  <name><![CDATA[Strict transport security not enforced]]></name>
+  <host ip="192.168.1.1">https://this.is.a.url</host>
+  <path><![CDATA[/]]></path>
+  <location><![CDATA[/]]></location>
+  <severity>Low</severity>
+  <confidence>Certain</confidence>
+  <issueBackground><![CDATA[<p> The application fails to prevent users from connecting  to it over unencrypted connections.  An attacker able to modify a legitimate user's network traffic could bypass the application's use of SSL/TLS encryption, and use the application as a platform for attacks against its users. This attack is performed by rewriting HTTPS links as HTTP, so that if a targeted user follows a link to the site from an HTTP page, their browser never attempts to use an encrypted connection. The sslstrip tool  automates this process. </p>
+<p>
+To exploit this vulnerability, an attacker must be suitably positioned to intercept and modify the victim's network traffic.This scenario typically occurs when a client communicates with the server over an insecure connection such as public Wi-Fi, or a corporate or home network that is shared with a compromised computer. Common defenses such as switched networks are not sufficient to prevent this. An attacker situated in the user's ISP or the application's hosting infrastructure could also perform this attack. Note that an advanced adversary could potentially target any connection made over the Internet's core infrastructure. </p>]]></issueBackground>
+  <remediationBackground><![CDATA[<p>The application should instruct web browsers to only access the application using HTTPS. To do this, enable HTTP Strict Transport Security (HSTS) by adding a response header with the name 'Strict-Transport-Security' and the value 'max-age=expireTime', where expireTime is the time in seconds that browsers should remember that the site should only be accessed using HTTPS. Consider adding the 'includeSubDomains' flag if appropriate.</p>
+<p>Note that because HSTS is a &quot;trust on first use&quot; (TOFU) protocol, a user who has never accessed the application will never have seen the HSTS header, and will therefore still be vulnerable to SSL stripping attacks. To mitigate this risk, you can optionally add the 'preload' flag to the HSTS header, and submit the domain for review by browser vendors.</p>]]></remediationBackground>
+  <references><![CDATA[<ul>
+<li><a href="https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security">HTTP Strict Transport Security</a></li>
+<li><a href="http://www.thoughtcrime.org/software/sslstrip/">sslstrip</a></li>
+<li><a href="https://hstspreload.appspot.com/">HSTS Preload Form</a></li>
+</ul>]]></references>
+  <vulnerabilityClassifications><![CDATA[<ul>
+<li><a href="https://cwe.mitre.org/data/definitions/523.html">CWE-523: Unprotected Transport of Credentials</a></li>
+</ul>]]></vulnerabilityClassifications>
 </issue>

--- a/templates/issue.template
+++ b/templates/issue.template
@@ -16,3 +16,7 @@
 
 #[RemediationDetails]#
 %issue.remediation_detail%
+
+
+#[References]#
+%issue.references%

--- a/templates/issue.template
+++ b/templates/issue.template
@@ -20,3 +20,7 @@
 
 #[References]#
 %issue.references%
+
+
+#[Classifications]#
+%issue.vulnerability_classifications%


### PR DESCRIPTION
This PR adds a few quick fixes to the Burp addon: 

- Adds `references` and `vulnerability_classifications` as available fields to Burp plugin. Resolves: https://github.com/dradis/dradis-ce/issues/128

- Adds `hostname` as a Node property, eliminating the old `#[HostInfo]#` Notes

- Fixes formatting errors including `<p>`, `<a href="">`, and `<table>` tags