### PR TITLE
Extension ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 *   Fixes formatting errors including `<p>`, `<a href="">`, and `<table>` tags
 
+*   Findings with <type>134217728</type> are not bundled together into one Issue
+
 ## Dradis Framework 3.9 (January, 2018) ##
 
 *   Encode content with UTF-8 to avoid incompatible db errors (v3.8.1)

--- a/lib/dradis/plugins/burp/importer.rb
+++ b/lib/dradis/plugins/burp/importer.rb
@@ -28,67 +28,100 @@ module Dradis::Plugins::Burp
       end
 
       # This will be filled in by the Processor while iterating over the issues
-      hosts         = []
-      affected_host = nil
-      issue_text    = nil
-      evidence_text = nil
+      @hosts         = []
+      @affected_host = nil
+      @issue_text    = nil
+      @evidence_text = nil
 
       doc.xpath('issues/issue').each do |xml_issue|
-        issue_name = xml_issue.at('name').text
-        issue_type = xml_issue.at('type').text.to_i
-
-        logger.info{ "Adding #{ issue_name } (#{ issue_type })" }
-
-        host_label = xml_issue.at('host')['ip']
-        host_label = xml_issue.at('host').text if host_label.empty?
-        affected_host = content_service.create_node(label: host_label, type: :host)
-        logger.info{ "\taffects: #{ host_label }" }
-
-        if !hosts.include?(affected_host.label)
-          hosts << affected_host.label
-          url = xml_issue.at('host').text
-          affected_host.set_property(:hostname, url)
-          affected_host.save
-        end
-
-        issue_text = template_service.process_template(
-          template: 'issue',
-          data: xml_issue)
-
-        if issue_text.include?(::Burp::INVALID_UTF_REPLACE)
-          logger.info %{
-            "\tdetected invalid UTF-8 bytes in your issue. " \
-            "Replacing them with '#{::Burp::INVALID_UTF_REPLACE}'."
-          }
-        end
-
-        issue = content_service.create_issue(
-          text: issue_text,
-          id: issue_type)
-
-        logger.info{ "\tadding evidence for this instance to #{ affected_host.label }."}
-
-        evidence_text = template_service.process_template(
-          template: 'evidence',
-          data: xml_issue
-        )
-
-        if evidence_text.include?(::Burp::INVALID_UTF_REPLACE)
-          logger.info {
-            "\tdetected invalid UTF-8 bytes in your evidence. " \
-            "Replacing them with '#{::Burp::INVALID_UTF_REPLACE}'."
-          }
-        end
-
-        content_service.create_evidence(
-          issue: issue,
-          node: affected_host,
-          content: evidence_text
-        )
-
+        process_report_host(xml_issue)
       end
+
       logger.info{ 'Burp Scanner results successfully imported' }
       return true
+
+    end
+
+    private
+    def process_report_host(xml_issue)
+      host_label = xml_issue.at('host')['ip']
+      host_label = xml_issue.at('host').text if host_label.empty?
+      affected_host = content_service.create_node(label: host_label, type: :host)
+      logger.info{ "\taffects: #{ host_label }" }
+
+      if !@hosts.include?(affected_host.label)
+        @hosts << affected_host.label
+        url = xml_issue.at('host').text
+        affected_host.set_property(:hostname, url)
+        affected_host.save
+      end
+
+      if xml_issue.at('type').text.to_str == "134217728"
+        process_extension_issues(affected_host, xml_issue)
+      else
+        process_burp_issues(affected_host, xml_issue)
+      end
+    end
+    
+    def process_burp_issues(affected_host, xml_issue)
+      issue_name = xml_issue.at('name').text
+      issue_type = xml_issue.at('type').text.to_i
+
+      logger.info{ "Adding #{ issue_name } (#{ issue_type })" }
+      issue_text = template_service.process_template(template: 'issue', data: xml_issue)
+
+      if issue_text.include?(::Burp::INVALID_UTF_REPLACE)
+        logger.info %{
+          "\tdetected invalid UTF-8 bytes in your issue. " \
+          "Replacing them with '#{::Burp::INVALID_UTF_REPLACE}'."
+        }
+      end
+
+      issue = content_service.create_issue(text: issue_text, id: issue_type)
+
+      logger.info{ "\tadding evidence for this instance to #{ affected_host.label }."}
+
+      evidence_text = template_service.process_template(template: 'evidence', data: xml_issue)
+
+      if evidence_text.include?(::Burp::INVALID_UTF_REPLACE)
+        logger.info {
+          "\tdetected invalid UTF-8 bytes in your evidence. " \
+          "Replacing them with '#{::Burp::INVALID_UTF_REPLACE}'."
+        }
+      end
+
+      content_service.create_evidence(issue: issue, node: affected_host, content: evidence_text)
+    end
+
+    def process_extension_issues(affected_host, xml_issue)
+      ext_name = xml_issue.at('name').text
+      ext_name = ext_name.gsub!(" ", "")
+
+      logger.info{ "Adding #{ ext_name })" }
+
+      issue_text = template_service.process_template(template: 'issue', data: xml_issue)
+
+      if issue_text.include?(::Burp::INVALID_UTF_REPLACE)
+        logger.info %{
+          "\tdetected invalid UTF-8 bytes in your issue. " \
+          "Replacing them with '#{::Burp::INVALID_UTF_REPLACE}'."
+        }
+      end
+
+      issue = content_service.create_issue(text: issue_text, id: ext_name)
+
+      logger.info{ "\tadding evidence for this instance to #{ affected_host.label }."}
+
+      evidence_text = template_service.process_template(template: 'evidence', data: xml_issue)
+
+      if evidence_text.include?(::Burp::INVALID_UTF_REPLACE)
+        logger.info {
+          "\tdetected invalid UTF-8 bytes in your evidence. " \
+          "Replacing them with '#{::Burp::INVALID_UTF_REPLACE}'."
+        }
+      end
+
+      content_service.create_evidence(issue: issue, node: affected_host, content: evidence_text)
     end
 
   end

--- a/lib/dradis/plugins/burp/importer.rb
+++ b/lib/dradis/plugins/burp/importer.rb
@@ -5,24 +5,24 @@ module Dradis::Plugins::Burp
     # the dropdown list and uploads a file.
     # @returns true if the operation was successful, false otherwise
     def import(params = {})
-      file_content = File.read( params[:file] )
+      file_content = File.read(params[:file])
 
       if file_content =~ /base64="false"/
         error =  "Burp input contains HTTP request / response data that hasn't been Base64-encoded.\n"
-        error << "Please re-export your scanner results making sure the Base-64 encode option is selected."
+        error << 'Please re-export your scanner results making sure the Base-64 encode option is selected.'
 
         logger.fatal{ error }
         content_service.create_note text: error
         return false
       end
 
-      logger.info{ 'Parsing Burp Scanner output file...' }
-      doc = Nokogiri::XML( file_content )
-      logger.info{'Done.'}
+      logger.info { 'Parsing Burp Scanner output file...' }
+      doc = Nokogiri::XML(file_content)
+      logger.info { 'Done.' }
 
       if doc.root.name != 'issues'
         error = "Document doesn't seem to be in the Burp Scanner XML format."
-        logger.fatal{ error }
+        logger.fatal { error }
         content_service.create_note text: error
         return false
       end
@@ -34,24 +34,23 @@ module Dradis::Plugins::Burp
       @evidence_text = nil
 
       doc.xpath('issues/issue').each do |xml_issue|
-        process_report_host(xml_issue)
+        process_issue(xml_issue)
       end
 
-      logger.info{ 'Burp Scanner results successfully imported' }
-      return true
-
+      logger.info { 'Burp Scanner results successfully imported' }
+      true
     end
 
     private
 
     # Creates the Nodes/properties
-    def process_report_host(xml_issue)
+    def process_issue(xml_issue)
       host_label = xml_issue.at('host')['ip']
       host_label = xml_issue.at('host').text if host_label.empty?
       affected_host = content_service.create_node(label: host_label, type: :host)
-      logger.info{ "\taffects: #{ host_label }" }
+      logger.info { "\taffects: #{host_label}" }
 
-      if !@hosts.include?(affected_host.label)
+      unless @hosts.include?(affected_host.label)
         @hosts << affected_host.label
         url = xml_issue.at('host').text
         affected_host.set_property(:hostname, url)
@@ -60,42 +59,25 @@ module Dradis::Plugins::Burp
 
       # Burp extensions don't follow the "unique type for every Issue" logic
       # so we have to deal with them separately
-      if xml_issue.at('type').text.to_str == "134217728"
+      if xml_issue.at('type').text.to_str == '134217728'
         process_extension_issues(affected_host, xml_issue)
       else
         process_burp_issues(affected_host, xml_issue)
       end
     end
-    
+
     # If the Issues come from the Burp app, use the type as the plugin_ic
     def process_burp_issues(affected_host, xml_issue)
       issue_name = xml_issue.at('name').text
       issue_type = xml_issue.at('type').text.to_i
 
-      logger.info{ "Adding #{ issue_name } (#{ issue_type })" }
-      issue_text = template_service.process_template(template: 'issue', data: xml_issue)
+      logger.info { "Adding #{issue_name} (#{issue_type})" }
 
-      if issue_text.include?(::Burp::INVALID_UTF_REPLACE)
-        logger.info %{
-          "\tdetected invalid UTF-8 bytes in your issue. " \
-          "Replacing them with '#{::Burp::INVALID_UTF_REPLACE}'."
-        }
-      end
-
-      issue = content_service.create_issue(text: issue_text, id: issue_type)
-
-      logger.info{ "\tadding evidence for this instance to #{ affected_host.label }."}
-
-      evidence_text = template_service.process_template(template: 'evidence', data: xml_issue)
-
-      if evidence_text.include?(::Burp::INVALID_UTF_REPLACE)
-        logger.info {
-          "\tdetected invalid UTF-8 bytes in your evidence. " \
-          "Replacing them with '#{::Burp::INVALID_UTF_REPLACE}'."
-        }
-      end
-
-      content_service.create_evidence(issue: issue, node: affected_host, content: evidence_text)
+      create_issue(
+        affected_host: affected_host,
+        id: issue_type,
+        xml_issue: xml_issue
+      )
     end
 
     # If the Issues come from a Burp extension (type = 134217728), then
@@ -104,32 +86,53 @@ module Dradis::Plugins::Burp
       ext_name = xml_issue.at('name').text
       ext_name = ext_name.gsub!(" ", "")
 
-      logger.info{ "Adding #{ ext_name }" }
+      logger.info { "Adding #{ext_name}" }
 
-      issue_text = template_service.process_template(template: 'issue', data: xml_issue)
-
-      if issue_text.include?(::Burp::INVALID_UTF_REPLACE)
-        logger.info %{
-          "\tdetected invalid UTF-8 bytes in your issue. " \
-          "Replacing them with '#{::Burp::INVALID_UTF_REPLACE}'."
-        }
-      end
-
-      issue = content_service.create_issue(text: issue_text, id: ext_name)
-
-      logger.info{ "\tadding evidence for this instance to #{ affected_host.label }."}
-
-      evidence_text = template_service.process_template(template: 'evidence', data: xml_issue)
-
-      if evidence_text.include?(::Burp::INVALID_UTF_REPLACE)
-        logger.info {
-          "\tdetected invalid UTF-8 bytes in your evidence. " \
-          "Replacing them with '#{::Burp::INVALID_UTF_REPLACE}'."
-        }
-      end
-
-      content_service.create_evidence(issue: issue, node: affected_host, content: evidence_text)
+      create_issue(
+        affected_host: affected_host,
+        id: ext_name,
+        xml_issue: xml_issue
+      )
     end
 
+    def create_issue(affected_host:, id:, xml_issue:)
+      issue_text =
+        template_service.process_template(
+          template: 'issue',
+          data: xml_issue
+        )
+
+      if issue_text.include?(::Burp::INVALID_UTF_REPLACE)
+        logger.info do
+          "\tdetected invalid UTF-8 bytes in your issue. " \
+          "Replacing them with '#{::Burp::INVALID_UTF_REPLACE}'."
+        end
+      end
+
+      issue = content_service.create_issue(text: issue_text, id: id)
+
+      logger.info do
+        "\tadding evidence for this instance to #{affected_host.label}."
+      end
+
+      evidence_text =
+        template_service.process_template(
+          template: 'evidence',
+          data: xml_issue
+        )
+
+      if evidence_text.include?(::Burp::INVALID_UTF_REPLACE)
+        logger.info do
+          "\tdetected invalid UTF-8 bytes in your evidence. " \
+          "Replacing them with '#{::Burp::INVALID_UTF_REPLACE}'."
+        end
+      end
+
+      content_service.create_evidence(
+        issue: issue,
+        node: affected_host,
+        content: evidence_text
+      )
+    end
   end
 end

--- a/lib/dradis/plugins/burp/importer.rb
+++ b/lib/dradis/plugins/burp/importer.rb
@@ -43,6 +43,8 @@ module Dradis::Plugins::Burp
     end
 
     private
+
+    # Creates the Nodes/properties
     def process_report_host(xml_issue)
       host_label = xml_issue.at('host')['ip']
       host_label = xml_issue.at('host').text if host_label.empty?
@@ -56,6 +58,8 @@ module Dradis::Plugins::Burp
         affected_host.save
       end
 
+      # Burp extensions don't follow the "unique type for every Issue" logic
+      # so we have to deal with them separately
       if xml_issue.at('type').text.to_str == "134217728"
         process_extension_issues(affected_host, xml_issue)
       else
@@ -63,6 +67,7 @@ module Dradis::Plugins::Burp
       end
     end
     
+    # If the Issues come from the Burp app, use the type as the plugin_ic
     def process_burp_issues(affected_host, xml_issue)
       issue_name = xml_issue.at('name').text
       issue_type = xml_issue.at('type').text.to_i
@@ -93,6 +98,8 @@ module Dradis::Plugins::Burp
       content_service.create_evidence(issue: issue, node: affected_host, content: evidence_text)
     end
 
+    # If the Issues come from a Burp extension (type = 134217728), then
+    # use the name (spaces removed) as the plugin_id
     def process_extension_issues(affected_host, xml_issue)
       ext_name = xml_issue.at('name').text
       ext_name = ext_name.gsub!(" ", "")

--- a/lib/dradis/plugins/burp/importer.rb
+++ b/lib/dradis/plugins/burp/importer.rb
@@ -104,7 +104,7 @@ module Dradis::Plugins::Burp
       ext_name = xml_issue.at('name').text
       ext_name = ext_name.gsub!(" ", "")
 
-      logger.info{ "Adding #{ ext_name })" }
+      logger.info{ "Adding #{ ext_name }" }
 
       issue_text = template_service.process_template(template: 'issue', data: xml_issue)
 

--- a/spec/burp_upload_spec.rb
+++ b/spec/burp_upload_spec.rb
@@ -62,6 +62,7 @@ describe 'Burp upload plugin' do
       # create_issue should be called once for each issue in the xml
       expect(@content_service).to receive(:create_issue) do |args|
         expect(args[:text]).to include("#[Title]#\nIssue 1")
+        expect(args[:id]).to eq(8781630)
         OpenStruct.new(args)
       end.once
       expect(@content_service).to receive(:create_evidence) do |args|
@@ -72,6 +73,7 @@ describe 'Burp upload plugin' do
 
       expect(@content_service).to receive(:create_issue) do |args|
         expect(args[:text]).to include("#[Title]#\nIssue 2")
+        expect(args[:id]).to eq(8781631)
         OpenStruct.new(args)
       end.once
       expect(@content_service).to receive(:create_evidence) do |args|
@@ -80,8 +82,12 @@ describe 'Burp upload plugin' do
         expect(args[:node].label).to eq("10.0.0.1")
       end.once
 
+      # Issue 3 is an Extension finding so we need to confirm
+      # that it triggers process_extension_issues instead of process_burp_issues
+      # and the plugin_id is not set to the Type (134217728)
       expect(@content_service).to receive(:create_issue) do |args|
         expect(args[:text]).to include("#[Title]#\nIssue 3")
+        expect(args[:id]).to eq("Issue3")
         OpenStruct.new(args)
       end.once
       expect(@content_service).to receive(:create_evidence) do |args|
@@ -92,6 +98,7 @@ describe 'Burp upload plugin' do
 
       expect(@content_service).to receive(:create_issue) do |args|
         expect(args[:text]).to include("#[Title]#\nIssue 4")
+        expect(args[:id]).to eq(8781633)
         OpenStruct.new(args)
       end.once
       expect(@content_service).to receive(:create_evidence) do |args|

--- a/spec/fixtures/files/burp.xml
+++ b/spec/fixtures/files/burp.xml
@@ -63,7 +63,7 @@
   </issue>
   <issue>
     <serialNumber>1833460934674078322</serialNumber>
-    <type>8781632</type>
+    <type>134217728</type>
     <name>Issue 3</name>
     <host ip="10.0.0.1">http://www.test.com</host>
     <path><![CDATA[/Common/login.aspx]]></path>


### PR DESCRIPTION
Burp extensions don't always follow the "One Type value for each finding" logic that Dradis is expecting. Based on the sample files we've collected, all of the extensions use: 
`<type>134217728</type>`

This PR updates our Burp plugin logic so findings with `<type>134217728</type>` are not bundled together into one Issue. Instead, they're split up based on the `<name>`. 