### PR TITLE
Make details available at the Evidence level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.12 (XXXX, 2019) ##
+
+*   Make `issue.detail` available at the Evidence level
+
 ## Dradis Framework 3.11 (November, 2018) ##
 
 *   No changes.

--- a/lib/dradis/plugins/burp/gem_version.rb
+++ b/lib/dradis/plugins/burp/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
 
       module VERSION
         MAJOR = 3
-        MINOR = 11
+        MINOR = 12
         TINY = 0
         PRE = nil
 

--- a/templates/evidence.fields
+++ b/templates/evidence.fields
@@ -5,3 +5,4 @@ issue.severity
 issue.confidence
 issue.request
 issue.response
+issue.detail

--- a/templates/evidence.template
+++ b/templates/evidence.template
@@ -1,26 +1,23 @@
 #[Host]#
 %issue.host%
 
+#[Details]#
+%issue.detail%
 
 #[Path]#
 %issue.path%
 
-
 #[Location]#
 %issue.location%
-
 
 #[Severity]#
 %issue.severity%
 
-
 #[Confidence]#
 %issue.confidence%
 
-
 #[Request]#
 bc.. %issue.request%
-
 
 #[Response]#
 bc.. %issue.response%

--- a/templates/evidence.template
+++ b/templates/evidence.template
@@ -1,9 +1,6 @@
 #[Host]#
 %issue.host%
 
-#[Details]#
-%issue.detail%
-
 #[Path]#
 %issue.path%
 


### PR DESCRIPTION
The `issue.detail` field is almost always the same from one instance to the next. But, in some specific circumstances (so far only in the [extension](https://github.com/dradis/dradis-burp/blob/650565811fbf5d6fb49e78a83e4a4cefbf5451c7/lib/dradis/plugins/burp/importer.rb#L83) issues), the `issue.detail` is unique to the instance. This PR makes the `issue.detail` field available at the Evidence level for import. 

Special thanks to Thomas for bringing this to our attention! 
