### PR TITLE
Issue severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
+## Dradis Framework 3.15 (Xxx, 2019) ##
+
+*   Make `issue.secerity` available at the Issue level.
+
 ## Dradis Framework 3.14 (August, 2019) ##
 
 *   No changes.
 
 ## Dradis Framework 3.13 (June, 2019) ##
 
-*   Include parsing Burp Html output
+*   Include parsing Burp Html output.
 
 ## Dradis Framework 3.12 (March, 2019) ##
 
-*   Make `issue.detail` available at the Evidence level
+*   Make `issue.detail` available at the Evidence level.
 
 ## Dradis Framework 3.11 (November, 2018) ##
 
@@ -16,17 +20,17 @@
 
 ## Dradis Framework 3.10 (August, 2018) ##
 
-*   Adds `references` and `vulnerability_classifications` as available fields
+*   Adds `references` and `vulnerability_classifications` as available fields.
 
-*   Adds `hostname` as a Node property
+*   Adds `hostname` as a Node property.
 
-*   Fixes formatting errors including `<p>`, `<a href="">`, and `<table>` tags
+*   Fixes formatting errors including `<p>`, `<a href="">`, and `<table>` tags.
 
-*   Findings with <type>134217728</type> are not bundled together into one Issue
+*   Findings with <type>134217728</type> are not bundled together into one Issue.
 
 ## Dradis Framework 3.9 (January, 2018) ##
 
-*   Encode content with UTF-8 to avoid incompatible db errors (v3.8.1)
+*   Encode content with UTF-8 to avoid incompatible db errors (v3.8.1).
 
 ## Dradis Framework 3.8 (September, 2017) ##
 

--- a/lib/dradis/plugins/burp/gem_version.rb
+++ b/lib/dradis/plugins/burp/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
 
       module VERSION
         MAJOR = 3
-        MINOR = 14
+        MINOR = 15
         TINY = 0
         PRE = nil
 

--- a/lib/dradis/plugins/burp/xml/importer.rb
+++ b/lib/dradis/plugins/burp/xml/importer.rb
@@ -13,7 +13,7 @@ module Dradis::Plugins::Burp
 
     class Importer < Dradis::Plugins::Upload::Importer
       BURP_EXTENSION_TYPE = '134217728'.freeze
-      BURP_SEVERITIES     = ['Information', 'Low', 'Medium', 'High', 'Critical'].freeze
+      BURP_SEVERITIES     = ['Information', 'Low', 'Medium', 'High'].freeze
 
       def initialize(args={})
         args[:plugin] = Dradis::Plugins::Burp

--- a/lib/dradis/plugins/burp/xml/importer.rb
+++ b/lib/dradis/plugins/burp/xml/importer.rb
@@ -12,10 +12,14 @@ module Dradis::Plugins::Burp
     end
 
     class Importer < Dradis::Plugins::Upload::Importer
+      BURP_EXTENSION_TYPE = '134217728'.freeze
+      BURP_SEVERITIES     = ['Information', 'Low', 'Medium', 'High', 'Critical'].freeze
+
       def initialize(args={})
         args[:plugin] = Dradis::Plugins::Burp
         super(args)
       end
+
       def import(params = {})
         file_content = File.read(params[:file])
 
@@ -33,80 +37,39 @@ module Dradis::Plugins::Burp
         logger.info { 'Done.' }
 
         if doc.root.name != 'issues'
-          error = "Document doesn't seem to be in the Burp Scanner XML format."
+          error = 'Document doesn\'t seem to be in the Burp Scanner XML format.'
           logger.fatal { error }
           content_service.create_note text: error
           return false
         end
 
         # This will be filled in by the Processor while iterating over the issues
-        @hosts         = []
-        @affected_host = nil
-        @issue_text    = nil
-        @evidence_text = nil
+        @issues     = []
+        @severities = Hash.new(0)
 
+        # We need to look ahead through all issues to bring the highest severity
+        # of each instance to the Issue level.
         doc.xpath('issues/issue').each do |xml_issue|
-          process_issue(xml_issue)
+          issue_id       = issue_id_for(xml_issue)
+          issue_severity = BURP_SEVERITIES.index(xml_issue.at('severity').text)
+
+          @severities[issue_id] = issue_severity if issue_severity > @severities[issue_id]
+          @issues << xml_issue
         end
+
+        @issues.each { |xml_issue| process_issue(xml_issue) }
 
         logger.info { 'Burp Scanner results successfully imported' }
         true
       end
 
-      # Creates the Nodes/properties
-      def process_issue(xml_issue)
-        host_label = xml_issue.at('host')['ip']
-        host_label = xml_issue.at('host').text if host_label.empty?
-        affected_host = content_service.create_node(label: host_label, type: :host)
-        logger.info { "\taffects: #{host_label}" }
-
-        unless @hosts.include?(affected_host.label)
-          @hosts << affected_host.label
-          url = xml_issue.at('host').text
-          affected_host.set_property(:hostname, url)
-          affected_host.save
-        end
-
-        # Burp extensions don't follow the "unique type for every Issue" logic
-        # so we have to deal with them separately
-        burp_extension_type = '134217728'.freeze
-        if xml_issue.at('type').text.to_str == burp_extension_type
-          process_extension_issues(affected_host, xml_issue)
-        else
-          process_burp_issues(affected_host, xml_issue)
-        end
-      end
-
-      # If the Issues come from the Burp app, use the type as the plugin_ic
-      def process_burp_issues(affected_host, xml_issue)
-        issue_name = xml_issue.at('name').text
-        issue_type = xml_issue.at('type').text.to_i
-
-        logger.info { "Adding #{issue_name} (#{issue_type})" }
-
-        create_issue(
-          affected_host: affected_host,
-          id: issue_type,
-          xml_issue: xml_issue
-        )
-      end
-
-      # If the Issues come from a Burp extension (type = 134217728), then
-      # use the name (spaces removed) as the plugin_id
-      def process_extension_issues(affected_host, xml_issue)
-        ext_name = xml_issue.at('name').text
-        ext_name = ext_name.gsub!(" ", "")
-
-        logger.info { "Adding #{ext_name}" }
-
-        create_issue(
-          affected_host: affected_host,
-          id: ext_name,
-          xml_issue: xml_issue
-        )
-      end
-
+      private
       def create_issue(affected_host:, id:, xml_issue:)
+        xml_evidence = xml_issue.clone
+
+        # Ensure that the Issue contains the highest Severity value
+        xml_issue.at('severity').content = BURP_SEVERITIES[@severities[id]]
+
         issue_text =
           template_service.process_template(
             template: 'issue',
@@ -129,7 +92,7 @@ module Dradis::Plugins::Burp
         evidence_text =
           template_service.process_template(
             template: 'evidence',
-            data: xml_issue
+            data: xml_evidence
           )
 
         if evidence_text.include?(::Burp::INVALID_UTF_REPLACE)
@@ -143,6 +106,37 @@ module Dradis::Plugins::Burp
           issue: issue,
           node: affected_host,
           content: evidence_text
+        )
+      end
+
+      # Burp extensions don't follow the "unique type for every Issue" logic
+      # so we have to deal with them separately
+      def issue_id_for(xml_issue)
+        if xml_issue.at('type').text == BURP_EXTENSION_TYPE
+          xml_issue.at('name').text.gsub!(' ', '')
+        else
+          xml_issue.at('type').text.to_i
+        end
+      end
+
+      # Creates the Nodes/properties
+      def process_issue(xml_issue)
+        host_url   = xml_issue.at('host').text
+        host_label = xml_issue.at('host')['ip']
+        host_label = host_url if host_label.empty?
+        issue_id   = issue_id_for(xml_issue)
+
+        affected_host = content_service.create_node(label: host_label, type: :host)
+        affected_host.set_property(:hostname, host_url)
+        affected_host.save
+
+        logger.info { "Adding #{xml_issue.at('name').text} (#{issue_id})"}
+        logger.info { "\taffects: #{host_label}" }
+
+        create_issue(
+          affected_host: affected_host,
+          id: issue_id,
+          xml_issue: xml_issue
         )
       end
     end

--- a/spec/fixtures/files/burp_issue_severity.xml
+++ b/spec/fixtures/files/burp_issue_severity.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0"?>
+<!DOCTYPE issues [
+<!ELEMENT issues (issue*)>
+<!ATTLIST issues burpVersion CDATA "">
+<!ATTLIST issues exportTime CDATA "">
+<!ELEMENT issue (serialNumber, type, name, host, path, location, severity, confidence, issueBackground?, remediationBackground?, issueDetail?, remediationDetail?, requestresponse*)>
+<!ELEMENT serialNumber (#PCDATA)>
+<!ELEMENT type (#PCDATA)>
+<!ELEMENT name (#PCDATA)>
+<!ELEMENT host (#PCDATA)>
+<!ATTLIST host ip CDATA "">
+<!ELEMENT path (#PCDATA)>
+<!ELEMENT location (#PCDATA)>
+<!ELEMENT severity (#PCDATA)>
+<!ELEMENT confidence (#PCDATA)>
+<!ELEMENT issueBackground (#PCDATA)>
+<!ELEMENT remediationBackground (#PCDATA)>
+<!ELEMENT issueDetail (#PCDATA)>
+<!ELEMENT remediationDetail (#PCDATA)>
+<!ELEMENT requestresponse (request?, response?, responseRedirected?)>
+<!ELEMENT request (#PCDATA)>
+<!ATTLIST request base64 (true|false) "false">
+<!ELEMENT response (#PCDATA)>
+<!ATTLIST response base64 (true|false) "false">
+<!ELEMENT responseRedirected (#PCDATA)>
+]>
+<issues burpVersion="1.5.14" exportTime="Wed Nov 10 17:26:55 EDT 2014">
+  <issue>
+    <serialNumber>1833460934674078320</serialNumber>
+    <type>8781630</type>
+    <name>Issue 1</name>
+    <host ip="10.0.0.1">http://www.test.com</host>
+    <path><![CDATA[/Common/login.aspx]]></path>
+    <location><![CDATA[/Common/login.aspx]]></location>
+    <severity>Information</severity>
+    <confidence>Firm</confidence>
+    <issueBackground><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit. Veniam fugiat possimus quaerat esse aspernatur cumque, fugit incidunt tempora nam ex atque, magni alias ullam illo voluptate sed consequatur reprehenderit qui.]]></issueBackground>
+    <remediationBackground><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit. Explicabo itaque unde numquam, nihil eveniet deleniti dignissimos architecto quo neque ea impedit nam autem iusto iste, esse, aut minus animi repellat.]]></remediationBackground>
+    <issueDetail><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit. Corporis quisquam aut necessitatibus ex possimus suscipit ipsam ipsa repellendus quo nostrum! Dolores quibusdam modi impedit nihil necessitatibus dicta vitae dolorem sit!]]></issueDetail>
+    <requestresponse>
+      <request base64="true"><![CDATA[TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2ljaW5nIGVsaXQuIFByb3ZpZGVudCBpcHN1bSBjb25zZWN0ZXR1ciBxdWlkZW0gb2JjYWVjYXRpIG5hdHVzLCByZW0gYXQgcXVhcyBzaW50IHRlbXBvcmUgYXV0ZW0gdm9sdXB0YXRpYnVzLCB2ZW5pYW0gZnVnaWF0IGN1bXF1ZSBsYWJvcmlvc2FtIG5lY2Vzc2l0YXRpYnVzIG9tbmlzIHJlaWNpZW5kaXMgdW5kZSBtYWduYW0u]]></request>
+      <response base64="true"><![CDATA[TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2ljaW5nIGVsaXQuIFNhcGllbnRlIGZ1Z2lhdCBlYXJ1bSwgYW5pbWkgdmVybyBxdWlidXNkYW0gc2VkLCBkb2xvcnVtIGRpc3RpbmN0aW8gYWxpcXVhbSwgcmVpY2llbmRpcyBjb3Jwb3JpcyBuaWhpbCBleGNlcHR1cmkgY29uc2VjdGV0dXIgZGVsZW5pdGkgbW9sZXN0aWFzIGhhcnVtIGxhYm9yaW9zYW0gc3VudCBub3N0cnVtIG9kaW8u]]></response>
+      <responseRedirected>false</responseRedirected>
+    </requestresponse>
+  </issue>
+  <issue>
+    <serialNumber>1833460934674078321</serialNumber>
+    <type>8781630</type>
+    <name>Issue 1</name>
+    <host ip="10.0.0.1">http://www.test.com</host>
+    <path><![CDATA[/Common/login.aspx]]></path>
+    <location><![CDATA[/Common/login.aspx]]></location>
+    <severity>High</severity>
+    <confidence>Firm</confidence>
+    <issueBackground><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit. Veniam fugiat possimus quaerat esse aspernatur cumque, fugit incidunt tempora nam ex atque, magni alias ullam illo voluptate sed consequatur reprehenderit qui.]]></issueBackground>
+    <remediationBackground><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit. Explicabo itaque unde numquam, nihil eveniet deleniti dignissimos architecto quo neque ea impedit nam autem iusto iste, esse, aut minus animi repellat.]]></remediationBackground>
+    <issueDetail><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit. Corporis quisquam aut necessitatibus ex possimus suscipit ipsam ipsa repellendus quo nostrum! Dolores quibusdam modi impedit nihil necessitatibus dicta vitae dolorem sit!]]></issueDetail>
+    <requestresponse>
+      <request base64="true"><![CDATA[TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2ljaW5nIGVsaXQuIFByb3ZpZGVudCBpcHN1bSBjb25zZWN0ZXR1ciBxdWlkZW0gb2JjYWVjYXRpIG5hdHVzLCByZW0gYXQgcXVhcyBzaW50IHRlbXBvcmUgYXV0ZW0gdm9sdXB0YXRpYnVzLCB2ZW5pYW0gZnVnaWF0IGN1bXF1ZSBsYWJvcmlvc2FtIG5lY2Vzc2l0YXRpYnVzIG9tbmlzIHJlaWNpZW5kaXMgdW5kZSBtYWduYW0u]]></request>
+      <response base64="true"><![CDATA[TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2ljaW5nIGVsaXQuIFNhcGllbnRlIGZ1Z2lhdCBlYXJ1bSwgYW5pbWkgdmVybyBxdWlidXNkYW0gc2VkLCBkb2xvcnVtIGRpc3RpbmN0aW8gYWxpcXVhbSwgcmVpY2llbmRpcyBjb3Jwb3JpcyBuaWhpbCBleGNlcHR1cmkgY29uc2VjdGV0dXIgZGVsZW5pdGkgbW9sZXN0aWFzIGhhcnVtIGxhYm9yaW9zYW0gc3VudCBub3N0cnVtIG9kaW8u]]></response>
+      <responseRedirected>false</responseRedirected>
+    </requestresponse>
+  </issue>
+  <issue>
+    <serialNumber>1833460934674078322</serialNumber>
+    <type>8781630</type>
+    <name>Issue 1</name>
+    <host ip="10.0.0.1">http://www.test.com</host>
+    <path><![CDATA[/Common/login.aspx]]></path>
+    <location><![CDATA[/Common/login.aspx]]></location>
+    <severity>Medium</severity>
+    <confidence>Firm</confidence>
+    <issueBackground><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit. Veniam fugiat possimus quaerat esse aspernatur cumque, fugit incidunt tempora nam ex atque, magni alias ullam illo voluptate sed consequatur reprehenderit qui.]]></issueBackground>
+    <remediationBackground><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit. Explicabo itaque unde numquam, nihil eveniet deleniti dignissimos architecto quo neque ea impedit nam autem iusto iste, esse, aut minus animi repellat.]]></remediationBackground>
+    <issueDetail><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit. Corporis quisquam aut necessitatibus ex possimus suscipit ipsam ipsa repellendus quo nostrum! Dolores quibusdam modi impedit nihil necessitatibus dicta vitae dolorem sit!]]></issueDetail>
+    <requestresponse>
+      <request base64="true"><![CDATA[TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2ljaW5nIGVsaXQuIFByb3ZpZGVudCBpcHN1bSBjb25zZWN0ZXR1ciBxdWlkZW0gb2JjYWVjYXRpIG5hdHVzLCByZW0gYXQgcXVhcyBzaW50IHRlbXBvcmUgYXV0ZW0gdm9sdXB0YXRpYnVzLCB2ZW5pYW0gZnVnaWF0IGN1bXF1ZSBsYWJvcmlvc2FtIG5lY2Vzc2l0YXRpYnVzIG9tbmlzIHJlaWNpZW5kaXMgdW5kZSBtYWduYW0u]]></request>
+      <response base64="true"><![CDATA[TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2ljaW5nIGVsaXQuIFNhcGllbnRlIGZ1Z2lhdCBlYXJ1bSwgYW5pbWkgdmVybyBxdWlidXNkYW0gc2VkLCBkb2xvcnVtIGRpc3RpbmN0aW8gYWxpcXVhbSwgcmVpY2llbmRpcyBjb3Jwb3JpcyBuaWhpbCBleGNlcHR1cmkgY29uc2VjdGV0dXIgZGVsZW5pdGkgbW9sZXN0aWFzIGhhcnVtIGxhYm9yaW9zYW0gc3VudCBub3N0cnVtIG9kaW8u]]></response>
+      <responseRedirected>false</responseRedirected>
+    </requestresponse>
+  </issue>
+  <issue>
+    <serialNumber>1833460934674078323</serialNumber>
+    <type>8781630</type>
+    <name>Issue 1</name>
+    <host ip="10.0.0.1">http://www.test.com</host>
+    <path><![CDATA[/Common/login.aspx]]></path>
+    <location><![CDATA[/Common/login.aspx]]></location>
+    <severity>Critical</severity>
+    <confidence>Firm</confidence>
+    <issueBackground><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit. Veniam fugiat possimus quaerat esse aspernatur cumque, fugit incidunt tempora nam ex atque, magni alias ullam illo voluptate sed consequatur reprehenderit qui.]]></issueBackground>
+    <remediationBackground><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit. Explicabo itaque unde numquam, nihil eveniet deleniti dignissimos architecto quo neque ea impedit nam autem iusto iste, esse, aut minus animi repellat.]]></remediationBackground>
+    <issueDetail><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit. Corporis quisquam aut necessitatibus ex possimus suscipit ipsam ipsa repellendus quo nostrum! Dolores quibusdam modi impedit nihil necessitatibus dicta vitae dolorem sit!]]></issueDetail>
+    <requestresponse>
+      <request base64="true"><![CDATA[TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2ljaW5nIGVsaXQuIFByb3ZpZGVudCBpcHN1bSBjb25zZWN0ZXR1ciBxdWlkZW0gb2JjYWVjYXRpIG5hdHVzLCByZW0gYXQgcXVhcyBzaW50IHRlbXBvcmUgYXV0ZW0gdm9sdXB0YXRpYnVzLCB2ZW5pYW0gZnVnaWF0IGN1bXF1ZSBsYWJvcmlvc2FtIG5lY2Vzc2l0YXRpYnVzIG9tbmlzIHJlaWNpZW5kaXMgdW5kZSBtYWduYW0u]]></request>
+      <response base64="true"><![CDATA[TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2ljaW5nIGVsaXQuIFNhcGllbnRlIGZ1Z2lhdCBlYXJ1bSwgYW5pbWkgdmVybyBxdWlidXNkYW0gc2VkLCBkb2xvcnVtIGRpc3RpbmN0aW8gYWxpcXVhbSwgcmVpY2llbmRpcyBjb3Jwb3JpcyBuaWhpbCBleGNlcHR1cmkgY29uc2VjdGV0dXIgZGVsZW5pdGkgbW9sZXN0aWFzIGhhcnVtIGxhYm9yaW9zYW0gc3VudCBub3N0cnVtIG9kaW8u]]></response>
+      <responseRedirected>false</responseRedirected>
+    </requestresponse>
+  </issue>
+  <issue>
+    <serialNumber>1833460934674078323</serialNumber>
+    <type>8781630</type>
+    <name>Issue 1</name>
+    <host ip="10.0.0.1">http://www.test.com</host>
+    <path><![CDATA[/Common/login.aspx]]></path>
+    <location><![CDATA[/Common/login.aspx]]></location>
+    <severity>Low</severity>
+    <confidence>Firm</confidence>
+    <issueBackground><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit. Veniam fugiat possimus quaerat esse aspernatur cumque, fugit incidunt tempora nam ex atque, magni alias ullam illo voluptate sed consequatur reprehenderit qui.]]></issueBackground>
+    <remediationBackground><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit. Explicabo itaque unde numquam, nihil eveniet deleniti dignissimos architecto quo neque ea impedit nam autem iusto iste, esse, aut minus animi repellat.]]></remediationBackground>
+    <issueDetail><![CDATA[Lorem ipsum dolor sit amet, consectetur adipisicing elit. Corporis quisquam aut necessitatibus ex possimus suscipit ipsam ipsa repellendus quo nostrum! Dolores quibusdam modi impedit nihil necessitatibus dicta vitae dolorem sit!]]></issueDetail>
+    <requestresponse>
+      <request base64="true"><![CDATA[TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2ljaW5nIGVsaXQuIFByb3ZpZGVudCBpcHN1bSBjb25zZWN0ZXR1ciBxdWlkZW0gb2JjYWVjYXRpIG5hdHVzLCByZW0gYXQgcXVhcyBzaW50IHRlbXBvcmUgYXV0ZW0gdm9sdXB0YXRpYnVzLCB2ZW5pYW0gZnVnaWF0IGN1bXF1ZSBsYWJvcmlvc2FtIG5lY2Vzc2l0YXRpYnVzIG9tbmlzIHJlaWNpZW5kaXMgdW5kZSBtYWduYW0u]]></request>
+      <response base64="true"><![CDATA[TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2ljaW5nIGVsaXQuIFNhcGllbnRlIGZ1Z2lhdCBlYXJ1bSwgYW5pbWkgdmVybyBxdWlidXNkYW0gc2VkLCBkb2xvcnVtIGRpc3RpbmN0aW8gYWxpcXVhbSwgcmVpY2llbmRpcyBjb3Jwb3JpcyBuaWhpbCBleGNlcHR1cmkgY29uc2VjdGV0dXIgZGVsZW5pdGkgbW9sZXN0aWFzIGhhcnVtIGxhYm9yaW9zYW0gc3VudCBub3N0cnVtIG9kaW8u]]></response>
+      <responseRedirected>false</responseRedirected>
+    </requestresponse>
+  </issue>
+</issues>

--- a/templates/issue.fields
+++ b/templates/issue.fields
@@ -1,7 +1,8 @@
-issue.name
 issue.background
-issue.remediation_background
 issue.detail
-issue.remediation_detail
+issue.name
 issue.references
+issue.remediation_background
+issue.remediation_detail
+issue.severity
 issue.vulnerability_classifications

--- a/templates/issue.template
+++ b/templates/issue.template
@@ -2,6 +2,10 @@
 %issue.name%
 
 
+#[Severity]#
+%issue.severity%
+
+
 #[Background]#
 %issue.background%
 


### PR DESCRIPTION
### Summary

This code makes `%issue.severity%` available in the Issue template.

The way it works is that the importer looks for all the instances of a given issue type in the Burp Scanner XML file and assigns the highest severity rating found.

In order to perform this, the Importer does a look-ahead operation and identifies all possible values of the `<severity>` field for a given issue type, choosing the highest one according to Burp's own rules.


### Other Information

Before this PR the flow inside `Importer` was from `#import` to `#process_issue` from there detecting whether it was a normal issue or a burp extension issue, and call `#process_burp_issues` or `#process_extension_issues`. These two methods were exactly the same (they both call `#create_issue`, they only differed in the way they assigned the issue ID: when a Burp issue, taking it from the `<id>`, when an Extension issue, taking it from the `<name>`.

This PR extracts that logic into `#issue_id_for` which basically looks at the `<id>` or `<name>` depending on the issue type.

As a result the flow inside `Importer` now goes from `#import` to `#process_issue` to `#create_issue`.