### PR TITLE
Highlight code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Dradis Framework 3.20 (XXX, 2020) ##
 
 *  Make `issue.location` available at the HTML Evidence level.
+*   Convert highlighted HTML code to Dradis highlight format
 
 ## Dradis Framework 3.19 (September, 2020) ##
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.20 (XXX, 2020) ##
+
+*  Make `issue.location` available at the HTML Evidence level.
+
 ## Dradis Framework 3.19 (September, 2020) ##
 
 *   No changes.

--- a/lib/burp/html/issue.rb
+++ b/lib/burp/html/issue.rb
@@ -126,6 +126,9 @@ module Burp
     def cleanup_request_response_html(source)
       result = source.dup
 
+      # Highlight code
+      result.gsub!(/<span class="HIGHLIGHT">(.+?)<\/span>/, '$${{\1}}$$')
+
       result.gsub!(/<b>(.*?)<\/b>/, '\1')
       result.gsub!(/<br>|<\/br>/){"\n"}
       result.gsub!(/<span.*?>/, '')

--- a/lib/burp/html/issue.rb
+++ b/lib/burp/html/issue.rb
@@ -19,7 +19,7 @@ module Burp
         :name, :type,
 
         # tags with contents retrieved following the span header
-        :background, :detail,
+        :background, :detail, :location,
         :references, :remediation_background, :remediation_detail,
         :request, :request_1, :request_2, :request_3,
         :response, :response_1, :response_2, :response_3,
@@ -83,6 +83,19 @@ module Burp
       # look for the h2 headers in the html fragment
       method_names = translations_table.fetch(method, method.to_s)
       method_names = [method_names].flatten
+
+      # Process the Location field
+      if method.to_s == 'location'
+        location = @html.at_xpath('/html/body/span[contains(@class, "BODH1")]')&.text
+
+        if location
+          # Remove the header number from the text.
+          # E.g. <span class="BODH1" id="1.1">1.1.&nbsp;/sample/text/</span>
+          return location.split(/[[:space:]]/).drop(1).join(' ')
+        else
+          return 'n/a'
+        end
+      end
 
       h2 = nil
       method_names.each do |method_name|

--- a/lib/dradis/plugins/burp/gem_version.rb
+++ b/lib/dradis/plugins/burp/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
 
       module VERSION
         MAJOR = 3
-        MINOR = 19
+        MINOR = 20
         TINY = 0
         PRE = nil
 

--- a/spec/burp_upload_spec.rb
+++ b/spec/burp_upload_spec.rb
@@ -114,11 +114,10 @@ describe 'Burp upload plugin' do
 
     it 'returns the highest <severity> at the Issue level' do
 
-      # create_issue should be called once for each issue in the xml
       expect(@content_service).to receive(:create_issue) do |args|
         expect(args[:id]).to eq(8781630)
         expect(args[:text]).to include("#[Title]#\nIssue 1")
-        expect(args[:text]).to include("#[Severity]#\nCritical")
+        expect(args[:text]).to include("#[Severity]#\nInformation")
         OpenStruct.new(args)
       end
 
@@ -129,23 +128,23 @@ describe 'Burp upload plugin' do
       end.once
       expect(@content_service).to receive(:create_evidence) do |args|
         expect(args[:content]).to include("#[Severity]#\nHigh")
-        expect(args[:issue].text).to include("#[Title]#\nIssue 1")
+        expect(args[:issue].text).to include("#[Title]#\nIssue 2")
         expect(args[:node].label).to eq('10.0.0.1')
         OpenStruct.new(args)
       end.once
       expect(@content_service).to receive(:create_evidence) do |args|
         expect(args[:content]).to include("#[Severity]#\nMedium")
-        expect(args[:issue].text).to include("#[Title]#\nIssue 1")
+        expect(args[:issue].text).to include("#[Title]#\nIssue 3")
         expect(args[:node].label).to eq('10.0.0.1')
       end.once
       expect(@content_service).to receive(:create_evidence) do |args|
-        expect(args[:content]).to include("#[Severity]#\nCritical")
-        expect(args[:issue].text).to include("#[Title]#\nIssue 1")
+        expect(args[:content]).to include("#[Severity]#\nHigh")
+        expect(args[:issue].text).to include("#[Title]#\nIssue 4")
         expect(args[:node].label).to eq('10.0.0.1')
       end.once
       expect(@content_service).to receive(:create_evidence) do |args|
         expect(args[:content]).to include("#[Severity]#\nLow")
-        expect(args[:issue].text).to include("#[Title]#\nIssue 1")
+        expect(args[:issue].text).to include("#[Title]#\nIssue 5")
         expect(args[:node].label).to eq('10.0.0.1')
       end.once
 
@@ -208,6 +207,7 @@ describe 'Burp upload plugin' do
       end.once
       expect(@content_service).to receive(:create_evidence) do |args|
         expect(args[:content]).to include("Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+        expect(args[:content]).to include("#[Location]#\nhttp://1.1.1.1/dradis/sessions")
         expect(args[:issue].text).to include("#[Title]#\nStrict transport security not enforced")
         expect(args[:node].label).to eq("github.com/dradis/dradis-burp")
       end.once

--- a/spec/fixtures/files/burp.html
+++ b/spec/fixtures/files/burp.html
@@ -179,8 +179,13 @@ div.scan_issue_medium_tentative_rpt{width: 32px; height: 32px; background-image:
 <div class="rule"></div>
 <h1>Contents</h1>
 <p class="TOCH0"><a href="#1">1.&nbsp;Strict transport security not enforced</a></p>
+<p class="TOCH1"><a href="#1.1">1.1.&nbsp;http://1.1.1.1/dradis/sessions</a></p>
 <br><div class="rule"></div>
 <span class="BODH0" id="1">1.&nbsp;<a href="https://portswigger.net/knowledgebase/issues/details/01000300_stricttransportsecuritynotenforced">Strict transport security not enforced</a></span>
+<br><span class="TEXT">There are 1 instances of this issue:
+<ul>
+<li><a href="#1.1">/dradis/sessions</a></li>
+</ul></span>
 <br>
 <h2>Summary</h2>
 <table cellpadding="0" cellspacing="0" class="summary_table">
@@ -218,6 +223,33 @@ To exploit this vulnerability, an attacker must be suitably positioned to interc
 <h2>Vulnerability classifications</h2><span class="TEXT"><ul>
 <li><a href="https://cwe.mitre.org/data/definitions/523.html">CWE-523: Unprotected Transport of Credentials</a></li>
 </ul></span>
+<br><div class="rule"></div>
+<span class="BODH1" id="2.1">1.1.&nbsp;http://1.1.1.1/dradis/sessions</span>
+<br><a class="PREVNEXT" href="#2.2">Next</a>
+<br>
+<h2>Summary</h2>
+<table cellpadding="0" cellspacing="0" class="summary_table">
+<tr>
+<td rowspan="4" class="icon" valign="top" align="center"><div class='scan_issue_high_certain_rpt'></div></td>
+<td>Severity:&nbsp;&nbsp;</td>
+<td><b>High</b></td>
+</tr>
+<tr>
+<td>Confidence:&nbsp;&nbsp;</td>
+<td><b>Certain</b></td>
+</tr>
+<tr>
+<td>Host:&nbsp;&nbsp;</td>
+<td><b>http://1.1.1.1</b></td>
+</tr>
+<tr>
+<td>Path:&nbsp;&nbsp;</td>
+<td><b>/dradis/sessions</b></td>
+</tr>
+</table>
+<h2>Issue detail</h2>
+<span class="TEXT">The page contains a form with the following action URL, which is submitted over clear-text HTTP:<ul><li>http://1.1.1.1/dradis/sessions</li></ul>The form contains the following password field:<ul><li>session[password]</li></ul></span>
+
 <h2>Request</h2>
 <div class="rr_div"><span>GET / HTTP/1.1<br>Host: github.com/dradis/dradis-burp<br>User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:66.0) Gecko/20100101 Firefox/66.0<br>Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8<br>Accept-Language: en,es-ES;q=0.8,es;q=0.5,en-US;q=0.3<br>Accept-Encoding: gzip, deflate<br>Connection: close<br>Cookie: hpage=1; AMCV_2387401053DB208C0A490D4C%40AdobeOrg=-1891778711%7CMCIDTS%7C17970%7CMCMID%7C21612935572021633722025223033275851039%7CMCAAMLH-1553169173%7C6%7CMCAAMB-1553169173%7CRKhpRz8krg2tLO6pguXWp5olkAcUniQYPHaMWWgdJ3xzPWQmdj0y%7CMCOPTOUT-1552571573s%7CNONE%7CMCAID%7CNONE%7CvVersion%7C2.4.0; uid=W9g/8Fux09NcLDHUBLt6Ag==#b4a7fa78e6c4983b02b41f0c993c2043; uid_ns=W9g/8Fux09NcLDHUBLt6Ag==; dtm_dds=3/14/2019%7C; s_lv=1538401711844; asaleatorio=v6|NO; _cb_ls=1; _cb=CHsEZNVjLgK9Eh3g; _chartbeat2=.1538380775140.1552564528405.0000000000000001.DULUU_5XcVyr-M7oTDU5YBMxsZ0.2; __gads=ID=06fd97433187c959:T=1538380762:S=ALNI_MZNHKQ5IoHIQX9fc91pDzlf7PDN4g; pbsconsent=BOU8kdHOU8kdHABABAENBq-AAAAht7_______9______9uz_Gv_v_f__33e8__9v_l_7_-___u_-33d4-_1vX99yfm1-7ftr3tp_86ues2_Xur_959_-njE; _v__chartbeat3=ChrB4_B73EobCceMDU; kppid=W9g/8Fux09NcLDHUBLt6Ag==; assegmento=v14|#feminismo; asnumdisplays=v14|1; aslastdisplay=v14|1552564374379; _fbp=fb.1.1552564376436.938848531; hst=1552520446_153124; cto_lwid=a6243aac-07e7-4c94-b258-b67ada2611d6; cto_idcpy=fec01c29-01e9-4fa7-b32d-b9ca0b82f535<br>Upgrade-Insecure-Requests: 1<br><br></span></div>
 <h2>Response</h2>


### PR DESCRIPTION
### Spec
Currently, when uploading burp HTML, we're ignoring the highlighted code even though we have that supported for Dradis.

**Proposed solution**
Replace instances of 

```
<span class="HIGHLIGHT">text</span>
```

with

```
$${{text}}$$
```

### How to test

1. Upload attached burp file
2. Visit the issue "Flash cross-domain policy"
3. Confirm that the evidence of that issue has highlighted text
