### PR TITLE
Html evidence detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Dradis Framework 3.20 (XXX, 2020) ##
 
 *  Make `issue.location` available at the HTML Evidence level.
+*   Convert highlighted HTML code to Dradis highlight format
 
 ## Dradis Framework 3.19 (September, 2020) ##
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Dradis Framework 3.20 (XXX, 2020) ##
 
-*  Make `issue.location` available at the HTML Evidence level.
 *   Convert highlighted HTML code to Dradis highlight format
+*   Make `issue.detail` available at the Evidence level for HTML uploads.
+*   Make `issue.location` available at the HTML Evidence level.
 
 ## Dradis Framework 3.19 (September, 2020) ##
 

--- a/lib/burp/html/issue.rb
+++ b/lib/burp/html/issue.rb
@@ -126,6 +126,9 @@ module Burp
     def cleanup_request_response_html(source)
       result = source.dup
 
+      # Highlight code
+      result.gsub!(/<span class="HIGHLIGHT">(.+?)<\/span>/, '$${{\1}}$$')
+
       result.gsub!(/<b>(.*?)<\/b>/, '\1')
       result.gsub!(/<br>|<\/br>/){"\n"}
       result.gsub!(/<span.*?>/, '')

--- a/templates/html_evidence.fields
+++ b/templates/html_evidence.fields
@@ -1,8 +1,8 @@
-issue.host
-issue.path
-issue.location
-issue.severity
 issue.confidence
+issue.detail
+issue.host
+issue.location
+issue.path
 issue.request
 issue.request_1
 issue.request_2
@@ -11,3 +11,4 @@ issue.response
 issue.response_1
 issue.response_2
 issue.response_3
+issue.severity


### PR DESCRIPTION
### Spec
Currently, the Issue Detail field in HTML Burp exports are not correctly imported to Dradis. While this field is already available for Issues, we're not preserving all the Issue Detail that are present in other issue instances in an HTML Burp export. This isn't an issue for Burp XML exports since the Issue Detail field is already present in the

**Proposed solution**
Make the `issue.detail` field available for the Evidence level

### How to test
1. Open the Plugins Manager and edit the Burp HTML evidence template to add the following field:
```
#[Detail]#
%issue.detail%
```
2. Upload the attached export to a project.
3. Visit the issue: Cleartext submission of password
4. Confirm that the issue's evidence show the correct Issue Details
