### PR TITLE
Use huge nokogiri option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-v4.7.0 (XXX 2022)
+v4.7.0 (XXX 2023)
   - Add support for large base64 response
 
 v4.6.0 (November 2022)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.7.0 (XXX 2022)
+  - Add support for large base64 response
+
 v4.6.0 (November 2022)
   - No changes
 

--- a/lib/dradis/plugins/burp/gem_version.rb
+++ b/lib/dradis/plugins/burp/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
 
       module VERSION
         MAJOR = 4
-        MINOR = 6
+        MINOR = 7
         TINY = 0
         PRE = nil
 

--- a/lib/dradis/plugins/burp/xml/importer.rb
+++ b/lib/dradis/plugins/burp/xml/importer.rb
@@ -37,7 +37,7 @@ module Dradis::Plugins::Burp
         end
 
         logger.info { 'Parsing Burp Scanner XML output file...' }
-        doc = Nokogiri::XML(file_content)
+        doc = Nokogiri::XML(file_content) { |config| config.huge }
         logger.info { 'Done.' }
 
         if doc.root.name != 'issues'


### PR DESCRIPTION
### Spec
When uploading a burp tool output with very large <response> values, the uploader returns an error:
```
<internal:pack>:309:in `unpack1': invalid base64 (ArgumentError)

from /opt/rbenv/versions/3.1.2/lib/ruby/3.1.0/base64.rb:74:in `strict_decode64'
```
This is because Nokogiri fails to parse the full <response> content due to its hardcoded limits.

**Proposed solution**
Add the huge option for Nokogiri in the importer.


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
