### PR TITLE
Replaces usage of Nokogiri's #search with #xpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.11.0 (January 2024)
+  - Changes nokogiri search to xpath to improve compatibility with versions >= 1.15
+
 v4.10.0 (September 2023)
   - Update gemspec links
 

--- a/lib/burp/html/issue.rb
+++ b/lib/burp/html/issue.rb
@@ -153,7 +153,7 @@ module Burp
         table = h2.next_element
 
         summary_table_tags.each do |tag|
-          td = table.search("td:starts-with('#{tag.to_s.capitalize}:')").first
+          td = table.xpath("//td[starts-with(.,'#{tag.to_s.capitalize}:')]").first
           @summary[tag] = td.next_element.text
         end
 

--- a/lib/dradis/plugins/burp/html/importer.rb
+++ b/lib/dradis/plugins/burp/html/importer.rb
@@ -90,7 +90,7 @@ module Dradis::Plugins::Burp
         evidence_id = html_evidence.attr('id').value
         logger.info { "Processing evidence #{evidence_id}" }
 
-        host_td    = html_evidence.search("td:starts-with('Host:')").first
+        host_td    = html_evidence.xpath("//td[starts-with(.,'Host:')]").first
         host_label = host_td.next_element.text.split('//').last
         host       = content_service.create_node(label: host_label, type: :host)
 


### PR DESCRIPTION
### Spec
The Burp HTML importer is not compatible with Nokogiri's newest versions (>= 1.15). When trying to upload a burp tool output, the uploader returns this error:
`evaluate: xmlXPathCompOpEval: function starts-with not found (Nokogiri::XML::XPath::SyntaxError)`

**Proposed solution**
Replace Nokogiri's search method wherever it is passed the `starts-with` option, with the equivalent query using XPath.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
