### PR TITLE
Add legacy mapping reference in mapping module

### DIFF
--- a/lib/dradis/plugins/burp/mapping.rb
+++ b/lib/dradis/plugins/burp/mapping.rb
@@ -2,5 +2,18 @@ module Dradis::Plugins::Burp
   module Mapping
     def self.default_mapping
     end
+
+    # since renaming template files to use a consistent structure,
+    # we need a reference to the old names in order to migrate the
+    # .template files to mapping records in the db
+    # { new_template_name => old_template_name }
+    def self.legacy_mapping_reference
+      {
+        'html_evidence' => 'html_evidence',
+        'html_issue' => 'issue',
+        'xml_evidence' => 'evidence',
+        'xml_issue' => 'issue'
+      }
+    end
   end
 end


### PR DESCRIPTION
### Summary

Since we are renaming Burp templates to use a consistent structure, we need a reference to the old names in order to migrate the existing `.template` files to mapping records in the db 
The legacy mapping reference is of the format:
`{ new_template_name => old_template_name }`


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.

### Check List

- [ ] Added a CHANGELOG entry
- [ ] Added specs
