### PR TITLE
Fix xpath and add stubbed mappings manager in specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-v4.14.0 (Month 2024)
+v4.X.X (Month 2024)
   - Fix HTML importer associating issues in the wrong node
 
 v4.13.0 (July 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.14.0 (Month 2024)
+  - Fix HTML importer associating issues in the wrong node
+
 v4.13.0 (July 2024)
   - No changes
 

--- a/lib/dradis/plugins/burp/gem_version.rb
+++ b/lib/dradis/plugins/burp/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
 
       module VERSION
         MAJOR = 4
-        MINOR = 15
+        MINOR = 16
         TINY = 0
         PRE = nil
 

--- a/lib/dradis/plugins/burp/html/importer.rb
+++ b/lib/dradis/plugins/burp/html/importer.rb
@@ -90,7 +90,7 @@ module Dradis::Plugins::Burp
         evidence_id = html_evidence.attr('id').value
         logger.info { "Processing evidence #{evidence_id}" }
 
-        host_td    = html_evidence.xpath("//td[starts-with(.,'Host:')]").first
+        host_td    = html_evidence.xpath(".//td[starts-with(.,'Host:')]").first
         host_label = host_td.next_element.text.split('//').last
         host       = content_service.create_node(label: host_label, type: :host)
 

--- a/lib/dradis/plugins/burp/html/importer.rb
+++ b/lib/dradis/plugins/burp/html/importer.rb
@@ -90,7 +90,7 @@ module Dradis::Plugins::Burp
         evidence_id = html_evidence.attr('id').value
         logger.info { "Processing evidence #{evidence_id}" }
 
-        host_td    = html_evidence.xpath(".//td[starts-with(.,'Host:')]").first
+        host_td    = html_evidence.at_xpath(".//td[starts-with(.,'Host:')]")
         host_label = host_td.next_element.text.split('//').last
         host       = content_service.create_node(label: host_label, type: :host)
 

--- a/spec/html/importer_spec.rb
+++ b/spec/html/importer_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+require 'ostruct'
+
+describe 'Burp upload plugin' do
+  describe Dradis::Plugins::Burp::Html::Importer do
+    before(:each) do
+      # Stub mappings service
+      allow(Dradis::Plugins::MappingService).to receive(:new).and_return(
+        StubbedMappingService.new
+      )
+
+      # Init services
+      plugin = Dradis::Plugins::Burp::Html
+
+      @content_service = Dradis::Plugins::ContentService::Base.new(
+        logger: Logger.new(STDOUT),
+        plugin: plugin
+      )
+
+      @importer = plugin::Importer.new(
+        content_service: @content_service,
+      )
+
+      # Stub dradis-plugins methods
+      #
+      # They return their argument hashes as objects mimicking
+      # Nodes, Issues, etc
+      allow(@content_service).to receive(:create_node) do |args|
+        obj = OpenStruct.new(args)
+        obj.define_singleton_method(:set_property) { |_, __| }
+        obj
+      end
+      allow(@content_service).to receive(:create_issue) do |args|
+        OpenStruct.new(args)
+      end
+      allow(@content_service).to receive(:create_evidence) do |args|
+        OpenStruct.new(args)
+      end
+    end
+
+    it 'creates nodes, issues, and evidence as needed' do
+      # Host node
+      #
+      # create_node should be called once for each issue in the xml,
+      # but ContentService knows it's already created and NOOPs
+      expect(@content_service).to receive(:create_node)
+      .with(hash_including label: 'github.com/dradis/dradis-burp')
+      .exactly(1).times
+
+      # # create_issue should be called once for each issue in the xml
+      expect(@content_service).to receive(:create_issue) do |args|
+        expect(args[:text]).to include("Strict transport security not enforced")
+        expect(args[:text]).to include('*application*', '@Wi-Fi@')
+        expect(args[:id]).to eq(16777984)
+        OpenStruct.new(args)
+      end.once
+      expect(@content_service).to receive(:create_evidence) do |args|
+        expect(args[:content]).to include('Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8')
+        expect(args[:content]).to include("http://1.1.1.1/dradis/sessions")
+        expect(args[:issue].text).to include("Strict transport security not enforced")
+        expect(args[:issue].text).to include('*application*', '@Wi-Fi@')
+        expect(args[:node].label).to eq('github.com/dradis/dradis-burp')
+      end.once
+
+      # Run the import
+      @importer.import(file: 'spec/fixtures/files/burp.html')
+    end
+  end
+end

--- a/spec/html/importer_spec.rb
+++ b/spec/html/importer_spec.rb
@@ -54,6 +54,7 @@ describe 'Burp upload plugin' do
         expect(args[:id]).to eq(16777984)
         OpenStruct.new(args)
       end.once
+      
       expect(@content_service).to receive(:create_evidence) do |args|
         expect(args[:content]).to include('Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8')
         expect(args[:content]).to include("http://1.1.1.1/dradis/sessions")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,3 +7,12 @@ Combustion.initialize!
 
 RSpec.configure do |config|
 end
+
+class StubbedMappingService
+  def apply_mapping(args)
+    processor = Dradis::Plugins::Burp::FieldProcessor.new(data: args[:data])
+    Dradis::Plugins::Burp::Mapping::SOURCE_FIELDS[args[:source].to_sym].map do |field|
+      processor.value(field: field)
+    end.join("\n")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,16 +3,9 @@ require 'bundler/setup'
 require 'nokogiri'
 require 'combustion'
 
+require 'support/stubbed_mapping_service'
+
 Combustion.initialize!
 
 RSpec.configure do |config|
-end
-
-class StubbedMappingService
-  def apply_mapping(args)
-    processor = Dradis::Plugins::Burp::FieldProcessor.new(data: args[:data])
-    Dradis::Plugins::Burp::Mapping::SOURCE_FIELDS[args[:source].to_sym].map do |field|
-      processor.value(field: field)
-    end.join("\n")
-  end
 end

--- a/spec/support/stubbed_mapping_service.rb
+++ b/spec/support/stubbed_mapping_service.rb
@@ -1,0 +1,8 @@
+class StubbedMappingService
+  def apply_mapping(args)
+    processor = Dradis::Plugins::Burp::FieldProcessor.new(data: args[:data])
+    Dradis::Plugins::Burp::Mapping::SOURCE_FIELDS[args[:source].to_sym].map do |field|
+      processor.value(field: field)
+    end.join("\n")
+  end
+end

--- a/spec/xml/importer_spec.rb
+++ b/spec/xml/importer_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require 'ostruct'
 
 describe 'Burp upload plugin' do
-
   describe Burp::Xml::Issue do
     it 'handles invalid utf-8 bytes' do
       doc = Nokogiri::XML(File.read('spec/fixtures/files/invalid-utf-issue.xml'))
@@ -15,10 +14,10 @@ describe 'Burp upload plugin' do
 
   describe Dradis::Plugins::Burp::Xml::Importer do
     before(:each) do
-      # Stub template service
-      templates_dir = File.expand_path('../../templates', __FILE__)
-      expect_any_instance_of(Dradis::Plugins::TemplateService)
-      .to receive(:default_templates_dir).and_return(templates_dir)
+      # Stub mappings service
+      allow(Dradis::Plugins::MappingService).to receive(:new).and_return(
+        StubbedMappingService.new
+      )
 
       # Init services
       plugin = Dradis::Plugins::Burp::Xml
@@ -50,7 +49,6 @@ describe 'Burp upload plugin' do
     end
 
     it 'creates nodes, issues, and evidence as needed' do
-
       # Host node
       #
       # create_node should be called once for each issue in the xml,
@@ -61,24 +59,24 @@ describe 'Burp upload plugin' do
 
       # create_issue should be called once for each issue in the xml
       expect(@content_service).to receive(:create_issue) do |args|
-        expect(args[:text]).to include("#[Title]#\nIssue 1")
+        expect(args[:text]).to include("Issue 1")
         expect(args[:id]).to eq(8781630)
         OpenStruct.new(args)
       end.once
       expect(@content_service).to receive(:create_evidence) do |args|
         expect(args[:content]).to include('Lorem ipsum dolor sit amet')
-        expect(args[:issue].text).to include("#[Title]#\nIssue 1")
+        expect(args[:issue].text).to include("Issue 1")
         expect(args[:node].label).to eq('10.0.0.1')
       end.once
 
       expect(@content_service).to receive(:create_issue) do |args|
-        expect(args[:text]).to include("#[Title]#\nIssue 2")
+        expect(args[:text]).to include("Issue 2")
         expect(args[:id]).to eq(8781631)
         OpenStruct.new(args)
       end.once
       expect(@content_service).to receive(:create_evidence) do |args|
         expect(args[:content]).to include('Lorem ipsum dolor sit amet')
-        expect(args[:issue].text).to include("#[Title]#\nIssue 2")
+        expect(args[:issue].text).to include("Issue 2")
         expect(args[:node].label).to eq('10.0.0.1')
       end.once
 
@@ -86,24 +84,24 @@ describe 'Burp upload plugin' do
       # that it triggers process_extension_issues instead of process_burp_issues
       # and the plugin_id is not set to the Type (134217728)
       expect(@content_service).to receive(:create_issue) do |args|
-        expect(args[:text]).to include("#[Title]#\nIssue 3")
+        expect(args[:text]).to include("Issue 3")
         expect(args[:id]).to eq('Issue3')
         OpenStruct.new(args)
       end.once
       expect(@content_service).to receive(:create_evidence) do |args|
         expect(args[:content]).to include('Lorem ipsum dolor sit amet')
-        expect(args[:issue].text).to include("#[Title]#\nIssue 3")
+        expect(args[:issue].text).to include("Issue 3")
         expect(args[:node].label).to eq('10.0.0.1')
       end.once
 
       expect(@content_service).to receive(:create_issue) do |args|
-        expect(args[:text]).to include("#[Title]#\nIssue 4")
+        expect(args[:text]).to include("Issue 4")
         expect(args[:id]).to eq(8781633)
         OpenStruct.new(args)
       end.once
       expect(@content_service).to receive(:create_evidence) do |args|
         expect(args[:content]).to include('Lorem ipsum dolor sit amet')
-        expect(args[:issue].text).to include("#[Title]#\nIssue 4")
+        expect(args[:issue].text).to include("Issue 4")
         expect(args[:node].label).to eq('10.0.0.1')
       end.once
 
@@ -112,110 +110,42 @@ describe 'Burp upload plugin' do
     end
 
     it 'returns the highest <severity> at the Issue level' do
-
       expect(@content_service).to receive(:create_issue) do |args|
         expect(args[:id]).to eq(8781630)
-        expect(args[:text]).to include("#[Title]#\nIssue 1")
-        expect(args[:text]).to include("#[Severity]#\nInformation")
+        expect(args[:text]).to include("Issue 1")
+        expect(args[:text]).to include("Information")
         OpenStruct.new(args)
       end
 
       expect(@content_service).to receive(:create_evidence) do |args|
-        expect(args[:content]).to include("#[Severity]#\nInformation")
-        expect(args[:issue].text).to include("#[Title]#\nIssue 1")
+        expect(args[:content]).to include("Information")
+        expect(args[:issue].text).to include("Issue 1")
         expect(args[:node].label).to eq('10.0.0.1')
       end.once
       expect(@content_service).to receive(:create_evidence) do |args|
-        expect(args[:content]).to include("#[Severity]#\nHigh")
-        expect(args[:issue].text).to include("#[Title]#\nIssue 2")
+        expect(args[:content]).to include("High")
+        expect(args[:issue].text).to include("Issue 2")
         expect(args[:node].label).to eq('10.0.0.1')
         OpenStruct.new(args)
       end.once
       expect(@content_service).to receive(:create_evidence) do |args|
-        expect(args[:content]).to include("#[Severity]#\nMedium")
-        expect(args[:issue].text).to include("#[Title]#\nIssue 3")
+        expect(args[:content]).to include("Medium")
+        expect(args[:issue].text).to include("Issue 3")
         expect(args[:node].label).to eq('10.0.0.1')
       end.once
       expect(@content_service).to receive(:create_evidence) do |args|
-        expect(args[:content]).to include("#[Severity]#\nHigh")
-        expect(args[:issue].text).to include("#[Title]#\nIssue 4")
+        expect(args[:content]).to include("High")
+        expect(args[:issue].text).to include("Issue 4")
         expect(args[:node].label).to eq('10.0.0.1')
       end.once
       expect(@content_service).to receive(:create_evidence) do |args|
-        expect(args[:content]).to include("#[Severity]#\nLow")
-        expect(args[:issue].text).to include("#[Title]#\nIssue 5")
+        expect(args[:content]).to include("Low")
+        expect(args[:issue].text).to include("Issue 5")
         expect(args[:node].label).to eq('10.0.0.1')
       end.once
 
       # Run the import
       @importer.import(file: 'spec/fixtures/files/burp_issue_severity.xml')
     end
-  end
-
-  describe Dradis::Plugins::Burp::Html::Importer do
-    before(:each) do
-      # Stub template service
-      templates_dir = File.expand_path('../../templates', __FILE__)
-      expect_any_instance_of(Dradis::Plugins::TemplateService)
-      .to receive(:default_templates_dir).and_return(templates_dir)
-
-      # Init services
-      plugin = Dradis::Plugins::Burp::Html
-
-      @content_service = Dradis::Plugins::ContentService::Base.new(
-        logger: Logger.new(STDOUT),
-        plugin: plugin
-      )
-
-      @importer = plugin::Importer.new(
-        content_service: @content_service,
-      )
-
-      # Stub dradis-plugins methods
-      #
-      # They return their argument hashes as objects mimicking
-      # Nodes, Issues, etc
-      allow(@content_service).to receive(:create_node) do |args|
-        obj = OpenStruct.new(args)
-        obj.define_singleton_method(:set_property) { |_, __| }
-        obj
-      end
-      allow(@content_service).to receive(:create_issue) do |args|
-        OpenStruct.new(args)
-      end
-      allow(@content_service).to receive(:create_evidence) do |args|
-        OpenStruct.new(args)
-      end
-    end
-
-    it 'creates nodes, issues, and evidence as needed' do
-
-      # Host node
-      #
-      # create_node should be called once for each issue in the xml,
-      # but ContentService knows it's already created and NOOPs
-      expect(@content_service).to receive(:create_node)
-      .with(hash_including label: 'github.com/dradis/dradis-burp')
-      .exactly(1).times
-
-      # # create_issue should be called once for each issue in the xml
-      expect(@content_service).to receive(:create_issue) do |args|
-        expect(args[:text]).to include("#[Title]#\nStrict transport security not enforced")
-        expect(args[:text]).to include('*application*', '@Wi-Fi@')
-        expect(args[:id]).to eq(16777984)
-        OpenStruct.new(args)
-      end.once
-      expect(@content_service).to receive(:create_evidence) do |args|
-        expect(args[:content]).to include('Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8')
-        expect(args[:content]).to include("#[Location]#\nhttp://1.1.1.1/dradis/sessions")
-        expect(args[:issue].text).to include("#[Title]#\nStrict transport security not enforced")
-        expect(args[:issue].text).to include('*application*', '@Wi-Fi@')
-        expect(args[:node].label).to eq('github.com/dradis/dradis-burp')
-      end.once
-
-      # Run the import
-      @importer.import(file: 'spec/fixtures/files/burp.html')
-    end
-
   end
 end


### PR DESCRIPTION
### Summary
The HTML importer is associating the issues in the first discovered node. This is happening because of the xpath we're using in the HTML importer:
```
html_evidence.xpath("//td[starts-with(.,'Host:')]").first
```
`//td...` will start a global search from the top level. We're calling #first afterwards so the first node in the document will always be selected.

**Proposed solution**
Use `.//td...` instead

Note that the PR also includes the following spec changes:

- Split the importer specs
- Stub the mappings manager service

### Check List

- [x] Added a CHANGELOG entry
- [x] Added specs
