### PR TITLE
Add support for multiple request response for Burp XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.17.0 (Month 2025)
+  - Add support for multiple Request/Response fields in XML
+
 v4.16.0 (May 2025)
   - Fix HTML importer associating issues in the wrong node
 

--- a/lib/burp/xml/issue.rb
+++ b/lib/burp/xml/issue.rb
@@ -1,127 +1,130 @@
 module Burp
   module Xml
-
-  # This class represents each of the /issues/issue elements in the Burp
-  # Scanner XML document.
-  #
-  # It provides a convenient way to access the information scattered all over
-  # the XML in attributes and nested tags.
-  #
-  # Instead of providing separate methods for each supported property we rely
-  # on Ruby's #method_missing to do most of the work.
-  class Issue < ::Burp::Issue
-
-    # Accepts an XML node from Nokogiri::XML.
-    def initialize(xml_node)
-      @xml = xml_node
-    end
-
-    # List of supported tags. They can be attributes, simple descendants or
-    # collections (e.g. <references/>, <tags/>)
-    def supported_tags
-      [
-        # attributes
-
-        # simple tags
-        :background, :confidence, :detail, :host, :location, :name, :path,
-        :references, :remediation_background, :remediation_detail,
-        :serial_number, :severity, :type,
-        :vulnerability_classifications,
-
-        # nested tags
-        :request, :response
-      ]
-    end
-
-    # This method is invoked by Ruby when a method that is not defined in this
-    # instance is called.
+    # This class represents each of the /issues/issue elements in the Burp
+    # Scanner XML document.
     #
-    # In our case we inspect the @method@ parameter and try to find the
-    # attribute, simple descendent or collection that it maps to in the XML
-    # tree.
-    def method_missing(method, *args)
+    # It provides a convenient way to access the information scattered all over
+    # the XML in attributes and nested tags.
+    #
+    # Instead of providing separate methods for each supported property we rely
+    # on Ruby's #method_missing to do most of the work.
+    class Issue < ::Burp::Issue
 
-      # We could remove this check and return nil for any non-recognized tag.
-      # The problem would be that it would make tricky to debug problems with
-      # typos. For instance: <>.potr would return nil instead of raising an
-      # exception
-      unless supported_tags.include?(method)
-        super
-        return
+      # Accepts an XML node from Nokogiri::XML.
+      def initialize(xml_node)
+        @xml = xml_node
       end
 
-      # First we try the attributes. In Ruby we use snake_case, but in XML
-      # CamelCase is used for some attributes
-      translations_table = {
-        background: 'issueBackground',
-        detail: 'issueDetail',
-        remediation_background: 'remediationBackground',
-        remediation_detail: 'remediationDetail',
-        vulnerability_classifications: 'vulnerabilityClassifications',
-        serial_number: 'serialNumber'
-      }
+      # List of supported tags. They can be attributes, simple descendants or
+      # collections (e.g. <references/>, <tags/>)
+      def supported_tags
+        [
+          # attributes
 
-      method_name = translations_table.fetch(method, method.to_s)
+          # simple tags
+          :background, :confidence, :detail, :host, :location, :name, :path,
+          :references, :remediation_background, :remediation_detail,
+          :serial_number, :severity, :type,
+          :vulnerability_classifications,
 
-      # no attributes in the <issue> node
-      # return @xml.attributes[method_name].value if @xml.attributes.key?(method_name)
-
-      # Then we try simple children tags: name, type, ...
-      tag = @xml.xpath("./#{method_name}").first
-      if tag && !tag.text.blank?
-        if tags_with_html_content.include?(method)
-          return cleanup_html(tag.text)
-        else
-          return tag.text
-        end
+          # nested tags
+          :request, :request_1, :request_2, :request_3,
+          :response, :response_1, :response_2, :response_3,
+        ]
       end
 
-      if (['request', 'response'].include?(method_name))
-        requestresponse_child(method_name)
-      else
-        # nothing found, the tag is valid but not present in this ReportItem
-        return nil
-      end
-    end
-
-    private
-
-    # Some of the values have embedded HTML content that we need to strip
-    def tags_with_html_content
-      [:background, :detail, :remediation_background, :remediation_detail, :references, :vulnerability_classifications]
-    end
-
-    def requestresponse_child(field)
-      return 'n/a' unless @xml.at('requestresponse') && @xml.at("requestresponse/#{field}")
-
-      xml_node = @xml.at("requestresponse/#{field}")
-      result = "[unprocessable #{field}]"
-
-      if xml_node['base64'] == 'true'
-        result = Base64::strict_decode64(xml_node.text)
-
-        # don't pass binary data to the DB.
-        if result =~ /\0/
-          header, _ = result.split("\r\n\r\n")
-          result = header << "\r\n\r\n" << '[Binary Data Not Displayed]'
-        end
-      else
-        result = xml_node.text
-      end
-
-      # Just in case a null byte was left by Burp
-      result.gsub!(/\0/,'&#00;')
-
-      # We truncate the request/response because it can be pretty big.
-      # If it is > 1M MySQL will die when trying to INSERT
+      # This method is invoked by Ruby when a method that is not defined in this
+      # instance is called.
       #
-      # TODO: maybe add a reference to this node's XPATH so the user can go
-      # back to the burp scanner file and look up the original request/response
-      result.truncate(50000, omission: '... (truncated)')
+      # In our case we inspect the @method@ parameter and try to find the
+      # attribute, simple descendent or collection that it maps to in the XML
+      # tree.
+      def method_missing(method, *args)
 
-      # Encode the string to UTF-8 to catch invalid bytes.
-      result.encode('utf-8', invalid: :replace, undef: :replace, replace: ::Burp::INVALID_UTF_REPLACE)
+        # We could remove this check and return nil for any non-recognized tag.
+        # The problem would be that it would make tricky to debug problems with
+        # typos. For instance: <>.potr would return nil instead of raising an
+        # exception
+        unless supported_tags.include?(method)
+          super
+          return
+        end
+
+        # First we try the attributes. In Ruby we use snake_case, but in XML
+        # CamelCase is used for some attributes
+        translations_table = {
+          background: 'issueBackground',
+          detail: 'issueDetail',
+          remediation_background: 'remediationBackground',
+          remediation_detail: 'remediationDetail',
+          vulnerability_classifications: 'vulnerabilityClassifications',
+          serial_number: 'serialNumber'
+        }
+
+        method_name = translations_table.fetch(method, method.to_s)
+
+        # no attributes in the <issue> node
+        # return @xml.attributes[method_name].value if @xml.attributes.key?(method_name)
+
+        # Then we try simple children tags: name, type, ...
+        tag = @xml.xpath("./#{method_name}").first
+        if tag && !tag.text.blank?
+          if tags_with_html_content.include?(method)
+            return cleanup_html(tag.text)
+          else
+            return tag.text
+          end
+        end
+
+        if (method_name.include?('request') || method_name.include?('response'))
+          requestresponse_child(method_name)
+        else
+          # nothing found, the tag is valid but not present in this ReportItem
+          return nil
+        end
+      end
+
+      private
+
+      # Some of the values have embedded HTML content that we need to strip
+      def tags_with_html_content
+        [:background, :detail, :remediation_background, :remediation_detail, :references, :vulnerability_classifications]
+      end
+
+      def requestresponse_child(field)
+        field_name, index = field.split('_')
+        index = index.to_i
+
+        return 'n/a' unless @xml.xpath('requestresponse')[index]
+
+        xml_node = @xml.xpath('requestresponse')[index].at(field_name)
+        result = "[unprocessable #{field}]"
+
+        if xml_node['base64'] == 'true'
+          result = Base64::strict_decode64(xml_node.text)
+
+          # don't pass binary data to the DB.
+          if result =~ /\0/
+            header, _ = result.split("\r\n\r\n")
+            result = header << "\r\n\r\n" << '[Binary Data Not Displayed]'
+          end
+        else
+          result = xml_node.text
+        end
+
+        # Just in case a null byte was left by Burp
+        result.gsub!(/\0/,'&#00;')
+
+        # We truncate the request/response because it can be pretty big.
+        # If it is > 1M MySQL will die when trying to INSERT
+        #
+        # TODO: maybe add a reference to this node's XPATH so the user can go
+        # back to the burp scanner file and look up the original request/response
+        result.truncate(50000, omission: '... (truncated)')
+
+        # Encode the string to UTF-8 to catch invalid bytes.
+        result.encode('utf-8', invalid: :replace, undef: :replace, replace: ::Burp::INVALID_UTF_REPLACE)
+      end
     end
   end
-end
 end

--- a/lib/burp/xml/issue.rb
+++ b/lib/burp/xml/issue.rb
@@ -63,9 +63,6 @@ module Burp
 
         method_name = translations_table.fetch(method, method.to_s)
 
-        # no attributes in the <issue> node
-        # return @xml.attributes[method_name].value if @xml.attributes.key?(method_name)
-
         # Then we try simple children tags: name, type, ...
         tag = @xml.xpath("./#{method_name}").first
         if tag && !tag.text.blank?
@@ -92,12 +89,16 @@ module Burp
       end
 
       def requestresponse_child(field)
+        # `field` is of the format: [request/response]_[index]
+        # Ex: `response_1` or `request_2`
         field_name, index = field.split('_')
         index = index.to_i
 
-        return 'n/a' unless @xml.xpath('requestresponse')[index]
+        request_response_xml = @xml.at_xpath("requestresponse[#{index + 1}]")
 
-        xml_node = @xml.xpath('requestresponse')[index].at(field_name)
+        return 'n/a' unless request_response_xml
+
+        xml_node = request_response_xml.at(field_name)
         result = "[unprocessable #{field}]"
 
         if xml_node['base64'] == 'true'

--- a/lib/dradis/plugins/burp/gem_version.rb
+++ b/lib/dradis/plugins/burp/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
 
       module VERSION
         MAJOR = 4
-        MINOR = 16
+        MINOR = 17
         TINY = 0
         PRE = nil
 

--- a/lib/dradis/plugins/burp/mapping.rb
+++ b/lib/dradis/plugins/burp/mapping.rb
@@ -89,7 +89,15 @@ module Dradis::Plugins::Burp
         'issue.confidence',
         'issue.request',
         'issue.response',
-        'issue.detail'
+        'issue.detail',
+        'issue.request',
+        'issue.request_1',
+        'issue.request_2',
+        'issue.request_3',
+        'issue.response',
+        'issue.response_1',
+        'issue.response_2',
+        'issue.response_3',
       ],
       xml_issue: [
         'issue.background',
@@ -99,7 +107,7 @@ module Dradis::Plugins::Burp
         'issue.remediation_background',
         'issue.remediation_detail',
         'issue.severity',
-        'issue.vulnerability_classifications'
+        'issue.vulnerability_classifications',
       ]
     }.freeze
   end

--- a/spec/fixtures/files/burp_issue_severity.xml
+++ b/spec/fixtures/files/burp_issue_severity.xml
@@ -114,5 +114,10 @@
       <response base64="true"><![CDATA[TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2ljaW5nIGVsaXQuIFNhcGllbnRlIGZ1Z2lhdCBlYXJ1bSwgYW5pbWkgdmVybyBxdWlidXNkYW0gc2VkLCBkb2xvcnVtIGRpc3RpbmN0aW8gYWxpcXVhbSwgcmVpY2llbmRpcyBjb3Jwb3JpcyBuaWhpbCBleGNlcHR1cmkgY29uc2VjdGV0dXIgZGVsZW5pdGkgbW9sZXN0aWFzIGhhcnVtIGxhYm9yaW9zYW0gc3VudCBub3N0cnVtIG9kaW8u]]></response>
       <responseRedirected>false</responseRedirected>
     </requestresponse>
+    <requestresponse>
+      <request base64="true"><![CDATA[dGVzdCBtdWx0aXBsZSByZXF1ZXN0]]></request>
+      <response base64="true"><![CDATA[dGVzdCBtdWx0aXBsZSByZXNwb25zZQ==]]></response>
+      <responseRedirected>false</responseRedirected>
+    </requestresponse>
   </issue>
 </issues>

--- a/spec/xml/importer_spec.rb
+++ b/spec/xml/importer_spec.rb
@@ -140,6 +140,8 @@ describe 'Burp upload plugin' do
       end.once
       expect(@content_service).to receive(:create_evidence) do |args|
         expect(args[:content]).to include("Low")
+        expect(args[:content]).to include("test multiple request")
+        expect(args[:content]).to include("test multiple response")
         expect(args[:issue].text).to include("Issue 5")
         expect(args[:node].label).to eq('10.0.0.1')
       end.once


### PR DESCRIPTION
### Spec
Currently, for Burp XML Evidence, we only have mappings for Request and Response. Only the first <requestresponse> data is being imported into the instance of Evidence. 

The goal is to import both (all) of the <requestresponse> tags into the instance of Evidence. There are up to 4 request/response fields in the Burp HTML report (Request, Request1, Request2, Request3).

 **Proposed solution**
Add support for the XML importer fields:
```
'Request' => 'bc.. {{ burp[issue.request] }}',
'Response' => 'bc.. {{ burp[issue.response] }}',
'Request 1' => 'bc.. {{ burp[issue.request_1] }}',
'Response 1' => 'bc.. {{ burp[issue.response_1] }}',
'Request 2' => 'bc.. {{ burp[issue.request_2] }}',
'Response 2' => 'bc.. {{ burp[issue.response_2] }}',
'Request 3' => 'bc.. {{ burp[issue.request_3] }}',
'Response 3' => 'bc.. {{ burp[issue.response_3] }}'
```

In lib/burp/xml/issue.rb, instead of fetching the first field with:

```
xml_node = @xml.at("requestresponse/#{field}")
```

We use the index defined from the field name (e.g. request_3). Something like:

```
xml_node = @xml.xpath("requestresponse")[index].at(field)
```

### Check List

- [x] Added a CHANGELOG entry
- [x] Added specs
