### PR TITLE
Add ID to available Issue fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v5.3.0 (XXXX 2026)
+  - Add Type as an available Issue field
+
 v5.2.0 (June 2026)
   - No changes
 

--- a/lib/dradis/plugins/burp/mapping.rb
+++ b/lib/dradis/plugins/burp/mapping.rb
@@ -75,6 +75,7 @@ module Dradis::Plugins::Burp
         'issue.background',
         'issue.detail',
         'issue.name',
+        'issue.type',
         'issue.references',
         'issue.remediation_background',
         'issue.remediation_detail',
@@ -92,6 +93,7 @@ module Dradis::Plugins::Burp
         'issue.detail'
       ],
       xml_issue: [
+        'issue.type',
         'issue.background',
         'issue.detail',
         'issue.name',


### PR DESCRIPTION
### Summary

This PR adds the Issue ID (type) to the available HTML and XML issue fields available in the Mappings Manager


### Testing Steps

1. Upload a report template if none exist. 
2. Configure a Burp XML and HTML Mapping for that template if none exist. If one exists, edit the existing Mapping to add a field called `ID` that contains `{{ burp[issue.type] }}` as the content. 
3. Upload a simple Burp XML file https://github.com/dradis/dradis-burp/blob/main/spec/fixtures/files/burp.xml and confirm that the Issues contain the ID field and the ID field is populated with a unique value for each Issue, matching the string from the XML for that Issue
4. Upload a simple Burp HTML file https://github.com/dradis/dradis-burp/blob/main/spec/fixtures/files/burp.html and confirm that the Issues contain the ID field and the ID field is populated with a unique value for each Issue, matching the string from the HTML for that Issue


### Copyright assignment

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.

### Check List

- [X] Added a CHANGELOG entry
- [X] Added specs
